### PR TITLE
rewards penalty if not enough

### DIFF
--- a/savings-account/Cargo.toml
+++ b/savings-account/Cargo.toml
@@ -11,9 +11,18 @@ path = "src/lib.rs"
 [dependencies.elrond-wasm]
 version = "0.25.0"
 
+[dependencies.price-aggregator-proxy]
+git = "https://github.com/ElrondNetwork/sc-chainlink-rs"
+rev = "c3ed77b"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.25.0"
 
-[dependencies.price-aggregator-proxy]
+[dev-dependencies]
+num-bigint = "0.4.2"
+num-traits = "0.2"
+hex = "0.4"
+
+[dev-dependencies.price-aggregator]
 git = "https://github.com/ElrondNetwork/sc-chainlink-rs"
 rev = "c3ed77b"

--- a/savings-account/mandos/calculate-rewards-multiple-calls.json
+++ b/savings-account/mandos/calculate-rewards-multiple-calls.json
@@ -341,7 +341,8 @@
                            "1-enum_type": "u8:1",
                            "2-prev_token_nonce": "u64:1",
                            "3-current_token_nonce": "u64:2",
-                           "4-total_rewards": "biguint:2500"
+                           "4-total_rewards": "biguint:2500",
+                           "5-nr_lenders_with_rewards": "u64:1"
                         },
 
                         "+": ""

--- a/savings-account/mandos/init.scen.json
+++ b/savings-account/mandos/init.scen.json
@@ -55,7 +55,7 @@
         {
             "step": "scDeploy",
             "txId": "deploy-savings-account",
-            "comment": "75% loan to value, 0.5% lender rewards per epoch, 50% base borrow rate, 10% for borrow rate under/over factor, 75% opt util, 60% reserve factor",
+            "comment": "75% loan to value, 0.5% lender rewards per epoch, 50% base borrow rate, 10% for borrow rate under/over factor, 75% opt util",
             "tx": {
                 "from": "address:owner",
                 "contractCode": "file:../output/savings-account.wasm",

--- a/savings-account/src/lib.rs
+++ b/savings-account/src/lib.rs
@@ -387,6 +387,8 @@ pub trait SavingsAccount:
         let mut rewards_amount = self.get_lender_claimable_rewards(payment_nonce, &payment_amount);
         let penalty_amount = self.penalty_amount_per_lender().get();
         if penalty_amount > 0u32 {
+            require!(rewards_amount > penalty_amount, "No rewards to claim");
+
             rewards_amount -= &penalty_amount;
 
             self.missing_rewards().update(|missing_rewards| {

--- a/savings-account/src/ongoing_operation.rs
+++ b/savings-account/src/ongoing_operation.rs
@@ -13,6 +13,7 @@ pub enum OngoingOperationType<M: ManagedTypeApi> {
         prev_lend_nonce: u64,
         current_lend_nonce: u64,
         total_rewards: BigUint<M>,
+        nr_lenders_with_rewards: u64,
     },
     ClaimStakingRewards {
         pos_id: u64,

--- a/savings-account/src/staking_rewards.rs
+++ b/savings-account/src/staking_rewards.rs
@@ -542,6 +542,7 @@ pub trait StakingRewardsModule:
     #[storage_mapper("missingRewards")]
     fn missing_rewards(&self) -> SingleValueMapper<BigUint>;
 
+    #[view(getPenaltyAmountPerLender)]
     #[storage_mapper("penaltyAmountPerLender")]
     fn penalty_amount_per_lender(&self) -> SingleValueMapper<BigUint>;
 

--- a/savings-account/src/staking_rewards.rs
+++ b/savings-account/src/staking_rewards.rs
@@ -314,16 +314,28 @@ pub trait StakingRewardsModule:
         let last_lend_nonce = self.last_valid_lend_nonce().get();
         require!(last_lend_nonce > 0, "No lenders");
 
-        let (mut prev_lend_nonce, mut current_lend_nonce, mut total_rewards) =
-            match self.load_operation() {
-                OngoingOperationType::None => (0u64, self.get_first_lend_nonce(), BigUint::zero()),
-                OngoingOperationType::CalculateTotalLenderRewards {
-                    prev_lend_nonce,
-                    current_lend_nonce,
-                    total_rewards,
-                } => (prev_lend_nonce, current_lend_nonce, total_rewards),
-                _ => return sc_error!(ANOTHER_ONGOING_OP_ERR_MSG),
-            };
+        let (
+            mut prev_lend_nonce,
+            mut current_lend_nonce,
+            mut total_rewards,
+            mut nr_lenders_with_rewards,
+        ) = match self.load_operation() {
+            OngoingOperationType::None => {
+                (0u64, self.get_first_lend_nonce(), BigUint::zero(), 0u64)
+            }
+            OngoingOperationType::CalculateTotalLenderRewards {
+                prev_lend_nonce,
+                current_lend_nonce,
+                total_rewards,
+                nr_lenders_with_rewards,
+            } => (
+                prev_lend_nonce,
+                current_lend_nonce,
+                total_rewards,
+                nr_lenders_with_rewards,
+            ),
+            _ => return sc_error!(ANOTHER_ONGOING_OP_ERR_MSG),
+        };
         let current_epoch = self.blockchain().get_block_epoch();
 
         let run_result = self.run_while_it_has_gas(
@@ -340,8 +352,11 @@ pub trait StakingRewardsModule:
                         current_epoch,
                         &reward_percentage_per_epoch,
                     );
+                    if reward_amount > 0u32 {
+                        nr_lenders_with_rewards += 1;
+                        total_rewards += reward_amount;
+                    }
 
-                    total_rewards += reward_amount;
                     prev_lend_nonce = current_lend_nonce;
                 }
 
@@ -355,25 +370,48 @@ pub trait StakingRewardsModule:
             None,
         )?;
 
+        let mut missing_rewards = self.missing_rewards().get();
+        total_rewards -= &missing_rewards;
+
         match run_result {
             OperationCompletionStatus::Completed => {
+                if nr_lenders_with_rewards == 0 {
+                    return Ok(run_result);
+                }
+
                 let prev_unclaimed_rewards = self.unclaimed_rewards().get();
                 let extra_unclaimed = &total_rewards - &prev_unclaimed_rewards;
-
-                // TODO: Maybe calculate by how much it's lower?
-                // For example, if 1000 is needed, but only 900 is available, that's 10% less
-                // So store this "10%" in storage and decrease everyone's rewards by 10% on lenderClaim?
                 let stablecoin_reserves = self.stablecoin_reserves().get();
-                require!(
-                    stablecoin_reserves >= extra_unclaimed,
-                    "Total rewards exceed reserves"
-                );
+
+                let mut leftover_reserves: BigUint;
+                if extra_unclaimed > stablecoin_reserves {
+                    let extra_missing_rewards = &extra_unclaimed - &stablecoin_reserves;
+                    total_rewards -= &extra_missing_rewards;
+                    missing_rewards += extra_missing_rewards;
+
+                    leftover_reserves = BigUint::zero();
+                } else {
+                    leftover_reserves = stablecoin_reserves - extra_unclaimed;
+                    if leftover_reserves >= missing_rewards {
+                        total_rewards += &missing_rewards;
+                        leftover_reserves -= &missing_rewards;
+                        missing_rewards = BigUint::zero();
+                    } else {
+                        total_rewards += &leftover_reserves;
+                        missing_rewards -= &leftover_reserves;
+                        leftover_reserves = BigUint::zero();
+                    }
+                }
+
+                // round up
+                let penalty_per_lender =
+                    (&missing_rewards + (nr_lenders_with_rewards - 1)) / nr_lenders_with_rewards;
+                self.penalty_amount_per_lender().set(&penalty_per_lender);
+                self.missing_rewards().set(&missing_rewards);
 
                 let current_epoch = self.blockchain().get_block_epoch();
                 self.last_calculate_rewards_epoch().set(&current_epoch);
                 self.unclaimed_rewards().set(&total_rewards);
-
-                let leftover_reserves = stablecoin_reserves - extra_unclaimed;
                 self.stablecoin_reserves().set(&leftover_reserves);
             }
             OperationCompletionStatus::InterruptedBeforeOutOfGas => {
@@ -381,6 +419,7 @@ pub trait StakingRewardsModule:
                     prev_lend_nonce,
                     current_lend_nonce,
                     total_rewards,
+                    nr_lenders_with_rewards,
                 });
             }
         };
@@ -499,6 +538,12 @@ pub trait StakingRewardsModule:
     #[view(getUnclaimedRewards)]
     #[storage_mapper("unclaimedRewards")]
     fn unclaimed_rewards(&self) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("missingRewards")]
+    fn missing_rewards(&self) -> SingleValueMapper<BigUint>;
+
+    #[storage_mapper("penaltyAmountPerLender")]
+    fn penalty_amount_per_lender(&self) -> SingleValueMapper<BigUint>;
 
     #[view(getStablecoinReserves)]
     #[storage_mapper("stablecoinReserves")]

--- a/savings-account/tests/test.rs
+++ b/savings-account/tests/test.rs
@@ -1,5 +1,5 @@
 use elrond_wasm::types::{
-    Address, EsdtLocalRole, ManagedBuffer, OperationCompletionStatus, SCResult,
+    Address, EsdtLocalRole, ManagedBuffer, OperationCompletionStatus, OptionalArg, SCResult,
 };
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
@@ -265,6 +265,7 @@ fn test_rewards_penalty() {
                 managed_token_id!(LEND_TOKEN_ID),
                 1,
                 managed_biguint!(100_000),
+                OptionalArg::None,
             );
             unwrap_or_panic(result);
 
@@ -330,6 +331,7 @@ fn test_rewards_penalty() {
                 managed_token_id!(LEND_TOKEN_ID),
                 2,
                 managed_biguint!(100_000),
+                OptionalArg::None,
             );
             unwrap_or_panic(result);
 

--- a/savings-account/tests/test.rs
+++ b/savings-account/tests/test.rs
@@ -1,0 +1,345 @@
+use elrond_wasm::types::{
+    Address, EsdtLocalRole, ManagedBuffer, OperationCompletionStatus, SCResult,
+};
+use elrond_wasm_debug::{
+    managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
+    DebugApi,
+};
+use savings_account::staking_rewards::StakingRewardsModule;
+use savings_account::tokens::TokensModule;
+use savings_account::*;
+
+const DUMMY_WASM_PATH: &'static str = "";
+const STABLECOIN_TOKEN_ID: &[u8] = b"STABLE-123456";
+const LIQUID_STAKING_TOKEN_ID: &[u8] = b"LIQ-123456";
+const STAKED_TOKEN_ID: &[u8] = b"";
+const STAKED_TOKEN_TICKER: &[u8] = b"EGLD";
+const LOAN_TO_VALUE_PERCENTAGE: u64 = 750_000_000; // 75%
+const LENDER_REWARDS_PERCENTAGE_PER_EPOCH: u64 = 5_000_000; // 0.5%
+const BASE_BORROW_RATE: u64 = 500_000_000; // 50%
+const BORROW_RATE_UNDER_OPTIMAL_FACTOR: u64 = 100_000_000; // 10%
+const BORROW_RATE_OVER_OPTIMAL_FACTOR: u64 = 100_000_000; // 10%
+const OPTIMAL_UTILISATION: u64 = 750_000_000; // 75%
+
+const LEND_TOKEN_ID: &[u8] = b"LEND-123456";
+const BORROW_TOKEN_ID: &[u8] = b"BORROW-123456";
+
+struct SavingsAccountSetup<SavingsAccountObjBuilder>
+where
+    SavingsAccountObjBuilder:
+        'static + Copy + Fn(DebugApi) -> savings_account::ContractObj<DebugApi>,
+{
+    pub blockchain_wrapper: BlockchainStateWrapper,
+    pub owner_address: Address,
+    pub first_lender_address: Address,
+    pub second_lender_address: Address,
+    pub _first_borrower_address: Address,
+    pub _second_borrower_address: Address,
+    pub sa_wrapper:
+        ContractObjWrapper<savings_account::ContractObj<DebugApi>, SavingsAccountObjBuilder>,
+}
+
+fn setup_savings_account<SavingsAccountObjBuilder>(
+    sa_builder: SavingsAccountObjBuilder,
+) -> SavingsAccountSetup<SavingsAccountObjBuilder>
+where
+    SavingsAccountObjBuilder:
+        'static + Copy + Fn(DebugApi) -> savings_account::ContractObj<DebugApi>,
+{
+    let rust_zero = rust_biguint!(0u64);
+    let mut blockchain_wrapper = BlockchainStateWrapper::new();
+    let owner_address = blockchain_wrapper.create_user_account(&rust_zero);
+    let first_lender_address = blockchain_wrapper.create_user_account(&rust_zero);
+    let second_lender_address = blockchain_wrapper.create_user_account(&rust_zero);
+    let first_borrower_address = blockchain_wrapper.create_user_account(&rust_zero);
+    let second_borrower_address = blockchain_wrapper.create_user_account(&rust_zero);
+
+    blockchain_wrapper.set_block_epoch(10);
+
+    // they use the SavingsAccount SC builder, as we only really need their addresses
+    // Async calls don't work yet, so we can't use the other two contracts
+    let delegation_wrapper = blockchain_wrapper.create_sc_account(
+        &rust_zero,
+        Some(&owner_address),
+        sa_builder,
+        DUMMY_WASM_PATH,
+    );
+    let dex_wrapper = blockchain_wrapper.create_sc_account(
+        &rust_zero,
+        Some(&owner_address),
+        sa_builder,
+        DUMMY_WASM_PATH,
+    );
+
+    let price_aggregator_wrapper = blockchain_wrapper.create_sc_account(
+        &rust_zero,
+        Some(&owner_address),
+        price_aggregator::contract_obj,
+        DUMMY_WASM_PATH,
+    );
+    let sa_wrapper = blockchain_wrapper.create_sc_account(
+        &rust_zero,
+        Some(&owner_address),
+        sa_builder,
+        DUMMY_WASM_PATH,
+    );
+
+    blockchain_wrapper.set_esdt_balance(
+        &first_lender_address,
+        STABLECOIN_TOKEN_ID,
+        &rust_biguint!(100_000),
+    );
+    blockchain_wrapper.set_esdt_balance(
+        &second_lender_address,
+        STABLECOIN_TOKEN_ID,
+        &rust_biguint!(100_000),
+    );
+
+    let nft_balance = rust_biguint!(250) * rust_biguint!(1_000_000_000_000_000_000);
+    blockchain_wrapper.set_nft_balance(
+        &first_borrower_address,
+        LIQUID_STAKING_TOKEN_ID,
+        1,
+        &nft_balance,
+        &(),
+    );
+    blockchain_wrapper.set_nft_balance(
+        &second_borrower_address,
+        LIQUID_STAKING_TOKEN_ID,
+        2,
+        &nft_balance,
+        &(),
+    );
+
+    blockchain_wrapper.execute_tx(&owner_address, &sa_wrapper, &rust_zero, |sc| {
+        let result = sc.init(
+            managed_token_id!(STABLECOIN_TOKEN_ID),
+            managed_token_id!(LIQUID_STAKING_TOKEN_ID),
+            managed_token_id!(STAKED_TOKEN_ID),
+            ManagedBuffer::new_from_bytes(STAKED_TOKEN_TICKER),
+            managed_address!(delegation_wrapper.address_ref()),
+            managed_address!(dex_wrapper.address_ref()),
+            managed_address!(price_aggregator_wrapper.address_ref()),
+            managed_biguint!(LOAN_TO_VALUE_PERCENTAGE),
+            managed_biguint!(LENDER_REWARDS_PERCENTAGE_PER_EPOCH),
+            managed_biguint!(BASE_BORROW_RATE),
+            managed_biguint!(BORROW_RATE_UNDER_OPTIMAL_FACTOR),
+            managed_biguint!(BORROW_RATE_OVER_OPTIMAL_FACTOR),
+            managed_biguint!(OPTIMAL_UTILISATION),
+        );
+        unwrap_or_panic(result);
+
+        sc.lend_token_id().set(&managed_token_id!(LEND_TOKEN_ID));
+        sc.borrow_token_id()
+            .set(&managed_token_id!(BORROW_TOKEN_ID));
+
+        StateChange::Commit
+    });
+
+    let roles = [
+        EsdtLocalRole::NftCreate,
+        EsdtLocalRole::NftAddQuantity,
+        EsdtLocalRole::NftBurn,
+    ];
+    blockchain_wrapper.set_esdt_local_roles(sa_wrapper.address_ref(), LEND_TOKEN_ID, &roles[..]);
+    blockchain_wrapper.set_esdt_local_roles(sa_wrapper.address_ref(), BORROW_TOKEN_ID, &roles[..]);
+
+    SavingsAccountSetup {
+        blockchain_wrapper,
+        owner_address,
+        first_lender_address,
+        second_lender_address,
+        _first_borrower_address: first_borrower_address,
+        _second_borrower_address: second_borrower_address,
+        sa_wrapper,
+    }
+}
+
+fn unwrap_or_panic<T>(result: SCResult<T>) -> T {
+    match result {
+        SCResult::Ok(t) => t,
+        SCResult::Err(err) => {
+            let str = String::from_utf8(err.as_bytes().to_vec()).unwrap();
+            panic!("{}", str);
+        }
+    }
+}
+
+#[test]
+fn init_test() {
+    let _ = setup_savings_account(savings_account::contract_obj);
+}
+
+#[test]
+fn test_rewards_penalty() {
+    let mut sa_setup = setup_savings_account(savings_account::contract_obj);
+    let b_wrapper = &mut sa_setup.blockchain_wrapper;
+
+    b_wrapper.set_block_epoch(20);
+
+    b_wrapper.execute_esdt_transfer(
+        &sa_setup.first_lender_address,
+        &sa_setup.sa_wrapper,
+        STABLECOIN_TOKEN_ID,
+        0,
+        &rust_biguint!(100_000),
+        |sc| {
+            let result = sc.lend(
+                managed_token_id!(STABLECOIN_TOKEN_ID),
+                managed_biguint!(100_000),
+            );
+            unwrap_or_panic(result);
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.execute_esdt_transfer(
+        &sa_setup.second_lender_address,
+        &sa_setup.sa_wrapper,
+        STABLECOIN_TOKEN_ID,
+        0,
+        &rust_biguint!(100_000),
+        |sc| {
+            let result = sc.lend(
+                managed_token_id!(STABLECOIN_TOKEN_ID),
+                managed_biguint!(100_000),
+            );
+            unwrap_or_panic(result);
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.set_block_epoch(25);
+
+    // set state required for calculate rewards to be callable
+    b_wrapper.execute_tx(
+        &sa_setup.owner_address,
+        &sa_setup.sa_wrapper,
+        &rust_biguint!(0),
+        |sc| {
+            sc.last_staking_rewards_claim_epoch().set(&25);
+            sc.last_staking_token_convert_epoch().set(&25);
+            sc.stablecoin_reserves().set(&managed_biguint!(500));
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.execute_tx(
+        &sa_setup.owner_address,
+        &sa_setup.sa_wrapper,
+        &rust_biguint!(0),
+        |sc| {
+            let result = sc.calculate_total_lender_rewards();
+            let op_status = unwrap_or_panic(result);
+            assert_eq!(op_status, OperationCompletionStatus::Completed);
+
+            StateChange::Commit
+        },
+    );
+
+    // expected rewards is 0.5% * 100_000 * (5 epochs) = 2.5% * 100_000 = 2_500 per lender
+    // i.e. 5_000 total rewards
+    b_wrapper.execute_query(&sa_setup.sa_wrapper, |sc| {
+        let unclaimed_rewards = sc.unclaimed_rewards().get();
+        assert_eq!(unclaimed_rewards, managed_biguint!(500));
+
+        let missing_rewards = sc.missing_rewards().get();
+        assert_eq!(missing_rewards, managed_biguint!(4_500));
+
+        let penalty_per_lender = sc.penalty_amount_per_lender().get();
+        assert_eq!(penalty_per_lender, managed_biguint!(2_250));
+    });
+
+    // lender 1 claim, should claim 2_500 - 2_250 = 250
+    b_wrapper.execute_esdt_transfer(
+        &sa_setup.first_lender_address,
+        &sa_setup.sa_wrapper,
+        LEND_TOKEN_ID,
+        1,
+        &rust_biguint!(100_000),
+        |sc| {
+            let result = sc.lender_claim_rewards(
+                managed_token_id!(LEND_TOKEN_ID),
+                1,
+                managed_biguint!(100_000),
+            );
+            unwrap_or_panic(result);
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.check_esdt_balance(
+        &sa_setup.first_lender_address,
+        STABLECOIN_TOKEN_ID,
+        &rust_biguint!(250),
+    );
+
+    // assume lender2 waited and claimed rewards later, when penalty was lifted
+    b_wrapper.set_block_epoch(26);
+
+    b_wrapper.execute_tx(
+        &sa_setup.owner_address,
+        &sa_setup.sa_wrapper,
+        &rust_biguint!(0),
+        |sc| {
+            sc.last_staking_rewards_claim_epoch().set(&26);
+            sc.last_staking_token_convert_epoch().set(&26);
+            sc.stablecoin_reserves().set(&managed_biguint!(10_000));
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.execute_tx(
+        &sa_setup.owner_address,
+        &sa_setup.sa_wrapper,
+        &rust_biguint!(0),
+        |sc| {
+            let result = sc.calculate_total_lender_rewards();
+            let op_status = unwrap_or_panic(result);
+            assert_eq!(op_status, OperationCompletionStatus::Completed);
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.execute_query(&sa_setup.sa_wrapper, |sc| {
+        let unclaimed_rewards = sc.unclaimed_rewards().get();
+        assert_eq!(unclaimed_rewards, managed_biguint!(3_500));
+
+        let missing_rewards = sc.missing_rewards().get();
+        assert_eq!(missing_rewards, managed_biguint!(0));
+
+        let penalty_per_lender = sc.penalty_amount_per_lender().get();
+        assert_eq!(penalty_per_lender, managed_biguint!(0));
+    });
+
+    // lender 2 claim, will get the full amount of 3_000
+    b_wrapper.execute_esdt_transfer(
+        &sa_setup.second_lender_address,
+        &sa_setup.sa_wrapper,
+        LEND_TOKEN_ID,
+        2,
+        &rust_biguint!(100_000),
+        |sc| {
+            let result = sc.lender_claim_rewards(
+                managed_token_id!(LEND_TOKEN_ID),
+                2,
+                managed_biguint!(100_000),
+            );
+            unwrap_or_panic(result);
+
+            StateChange::Commit
+        },
+    );
+
+    b_wrapper.check_esdt_balance(
+        &sa_setup.second_lender_address,
+        STABLECOIN_TOKEN_ID,
+        &rust_biguint!(3_000),
+    );
+}


### PR DESCRIPTION
The previous implementation of giving an error if not enough reserves are available could lead into a snowball effect, where lenders could not claim any rewards ever again, since there are not enough borrowers.

The current implementation calculates how many rewards are missing, and applies a penalty to each user. The penalty is fixed per lender: `missing_rewards / nr_lenders`. An argument could be made for weighted penalty based on lend amount, but I think this simpler solution is good enough.

The algorithm makes sure the missing rewards are covered by extra reserves whenever possible.