### PR TITLE
Upgrade 0.30

### DIFF
--- a/delegation-mock/Cargo.toml
+++ b/delegation-mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
+version = "0.30.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"

--- a/delegation-mock/meta/Cargo.toml
+++ b/delegation-mock/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"

--- a/delegation-mock/wasm/Cargo.toml
+++ b/delegation-mock/wasm/Cargo.toml
@@ -21,9 +21,9 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.25.0"
+version = "0.30.0"
 features = [ "vm-validate-token-identifier" ]
 
 [dependencies.elrond-wasm-output]
-version = "0.25.0"
+version = "0.30.0"
 features = [ "wasm-output-mode" ]

--- a/delegation-mock/wasm/src/lib.rs
+++ b/delegation-mock/wasm/src/lib.rs
@@ -7,7 +7,6 @@
 elrond_wasm_node::wasm_endpoints! {
     delegation_mock
     (
-        init
         claimRewards
         stake
     )

--- a/dex-mock/Cargo.toml
+++ b/dex-mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
+version = "0.30.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"

--- a/dex-mock/meta/Cargo.toml
+++ b/dex-mock/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"

--- a/dex-mock/src/lib.rs
+++ b/dex-mock/src/lib.rs
@@ -22,16 +22,16 @@ pub trait DexMock {
         #[payment_amount] amount_in: BigUint,
         token_out: TokenIdentifier,
         _amount_out_min: BigUint,
-        #[var_args] opt_accept_funds_func: OptionalArg<ManagedBuffer>,
+        #[var_args] opt_accept_funds_func: OptionalValue<ManagedBuffer>,
     ) -> EsdtTokenPayment<Self::Api> {
         let caller = self.blockchain().get_caller();
         let amount_out = amount_in * 100u64 / EGLD_DECIMALS;
         let func = match opt_accept_funds_func {
-            OptionalArg::Some(f) => f,
-            OptionalArg::None => ManagedBuffer::default(),
+            OptionalValue::Some(f) => f,
+            OptionalValue::None => ManagedBuffer::default(),
         };
 
-        let _ = self.raw_vm_api().direct_esdt_execute(
+        let _ = Self::Api::send_api_impl().direct_esdt_execute(
             &caller,
             &token_out,
             &amount_out,

--- a/dex-mock/wasm/Cargo.toml
+++ b/dex-mock/wasm/Cargo.toml
@@ -21,8 +21,8 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.25.0"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-output]
-version = "0.25.0"
+version = "0.30.0"
 features = ["wasm-output-mode"]

--- a/dex-mock/wasm/src/lib.rs
+++ b/dex-mock/wasm/src/lib.rs
@@ -7,7 +7,6 @@
 elrond_wasm_node::wasm_endpoints! {
     dex_mock
     (
-        init
         deposit
         swapTokensFixedInput
     )

--- a/savings-account/Cargo.toml
+++ b/savings-account/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/lib.rs"
 [dependencies.elrond-wasm]
 version = "0.30.0"
 
+[dependencies.elrond-wasm-modules]
+version = "0.30.0"
+
 [dev-dependencies.elrond-wasm-debug]
 version = "0.30.0"
 

--- a/savings-account/Cargo.toml
+++ b/savings-account/Cargo.toml
@@ -9,14 +9,10 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
-
-[dependencies.price-aggregator-proxy]
-git = "https://github.com/ElrondNetwork/sc-chainlink-rs"
-rev = "c3ed77b"
+version = "0.30.0"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"
 
 [dev-dependencies]
 num-bigint = "0.4.2"
@@ -25,4 +21,4 @@ hex = "0.4"
 
 [dev-dependencies.price-aggregator]
 git = "https://github.com/ElrondNetwork/sc-chainlink-rs"
-rev = "c3ed77b"
+rev = "4d4f125"

--- a/savings-account/meta/Cargo.toml
+++ b/savings-account/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.25.0"
+version = "0.30.0"
 
 [dependencies.elrond-wasm-debug]
-version = "0.25.0"
+version = "0.30.0"

--- a/savings-account/src/math.rs
+++ b/savings-account/src/math.rs
@@ -32,7 +32,7 @@ pub trait MathModule {
         borrowed_amount: &BigUint,
         total_pool_reserves: &BigUint,
     ) -> BigUint {
-        &(borrowed_amount * BASE_PRECISION) / total_pool_reserves
+        (borrowed_amount * BASE_PRECISION) / total_pool_reserves
     }
 
     fn compute_staking_position_value(

--- a/savings-account/src/math.rs
+++ b/savings-account/src/math.rs
@@ -14,13 +14,12 @@ pub trait MathModule {
         u_optimal: &BigUint,
         u_current: &BigUint,
     ) -> BigUint {
-        let bp = BigUint::from(BASE_PRECISION);
-
         if u_current < u_optimal {
             let utilisation_ratio = &(u_current * r_slope1) / u_optimal;
 
             r_base + &utilisation_ratio
         } else {
+            let bp = BigUint::from(BASE_PRECISION);
             let denominator = &bp - u_optimal;
             let numerator = &(u_current - u_optimal) * r_slope2;
 
@@ -33,8 +32,7 @@ pub trait MathModule {
         borrowed_amount: &BigUint,
         total_pool_reserves: &BigUint,
     ) -> BigUint {
-        let bp = BigUint::from(BASE_PRECISION);
-        &(borrowed_amount * &bp) / total_pool_reserves
+        &(borrowed_amount * BASE_PRECISION) / total_pool_reserves
     }
 
     fn compute_staking_position_value(
@@ -54,8 +52,7 @@ pub trait MathModule {
         let epoch_diff = current_epoch - borrow_epoch;
 
         let bp = BigUint::from(BASE_PRECISION);
-        let epochs_year = BigUint::from(EPOCHS_IN_YEAR);
-        let time_unit_percentage = (&epoch_diff.into() * &bp) / epochs_year;
+        let time_unit_percentage = (&epoch_diff.into() * &bp) / EPOCHS_IN_YEAR;
         let debt_percetange = &(&time_unit_percentage * borrow_rate) / &bp;
 
         (&debt_percetange * amount) / bp
@@ -73,9 +70,8 @@ pub trait MathModule {
         }
 
         let epoch_diff = last_calculate_rewards_epoch - lend_epoch;
-        let bp = BigUint::from(BASE_PRECISION);
         let percentage = &epoch_diff.into() * reward_percentage_per_epoch;
 
-        (&percentage * amount) / bp
+        (&percentage * amount) / BASE_PRECISION
     }
 }

--- a/savings-account/src/ongoing_operation.rs
+++ b/savings-account/src/ongoing_operation.rs
@@ -41,7 +41,7 @@ pub trait OngoingOperationModule {
         &self,
         mut process: Process,
         opt_additional_gas_reserve_per_iteration: Option<u64>,
-    ) -> SCResult<OperationCompletionStatus>
+    ) -> OperationCompletionStatus
     where
         Process: FnMut() -> LoopOp<Self::Api>,
     {
@@ -63,7 +63,7 @@ pub trait OngoingOperationModule {
 
             total_reserve_needed += additional_gas_reserve_per_iteration;
             if !self.can_continue_operation(gas_per_iteration, total_reserve_needed) {
-                return Ok(OperationCompletionStatus::InterruptedBeforeOutOfGas);
+                return OperationCompletionStatus::InterruptedBeforeOutOfGas;
             }
 
             loop_op = process();
@@ -71,7 +71,7 @@ pub trait OngoingOperationModule {
 
         self.clear_operation();
 
-        Ok(OperationCompletionStatus::Completed)
+        OperationCompletionStatus::Completed
     }
 
     fn can_continue_operation(&self, operation_cost: u64, extra_reserve_needed: u64) -> bool {
@@ -92,12 +92,11 @@ pub trait OngoingOperationModule {
         self.current_ongoing_operation().clear();
     }
 
-    fn require_no_ongoing_operation(&self) -> SCResult<()> {
+    fn require_no_ongoing_operation(&self) {
         require!(
             self.current_ongoing_operation().is_empty(),
             "Ongoing operation in progress"
         );
-        Ok(())
     }
 
     #[storage_mapper("currentOngoingOperation")]

--- a/savings-account/src/ongoing_operation.rs
+++ b/savings-account/src/ongoing_operation.rs
@@ -80,14 +80,17 @@ pub trait OngoingOperationModule {
         gas_left > MIN_GAS_TO_SAVE_PROGRESS + extra_reserve_needed + operation_cost
     }
 
+    #[inline]
     fn load_operation(&self) -> OngoingOperationType<Self::Api> {
         self.current_ongoing_operation().get()
     }
 
+    #[inline]
     fn save_progress(&self, operation: &OngoingOperationType<Self::Api>) {
         self.current_ongoing_operation().set(operation);
     }
 
+    #[inline]
     fn clear_operation(&self) {
         self.current_ongoing_operation().clear();
     }

--- a/savings-account/src/ongoing_operation.rs
+++ b/savings-account/src/ongoing_operation.rs
@@ -20,7 +20,6 @@ pub enum OngoingOperationType<M: ManagedTypeApi> {
         async_call_fire_round: u64,
         callback_executed: bool,
     },
-    ConvertStakingTokenToStablecoin,
 }
 
 pub enum LoopOp<M: ManagedTypeApi> {

--- a/savings-account/src/price_aggregator_proxy.rs
+++ b/savings-account/src/price_aggregator_proxy.rs
@@ -1,0 +1,93 @@
+elrond_wasm::imports!();
+
+pub const DOLLAR_TICKER: &[u8] = b"USD";
+
+pub type AggregatorResultAsMultiResult<M> =
+    MultiValue5<u32, ManagedBuffer<M>, ManagedBuffer<M>, BigUint<M>, u8>;
+
+mod price_aggregator_proxy {
+    elrond_wasm::imports!();
+
+    #[elrond_wasm::proxy]
+    pub trait PriceAggregator {
+        #[view(latestPriceFeedOptional)]
+        fn latest_price_feed_optional(
+            &self,
+            from: ManagedBuffer,
+            to: ManagedBuffer,
+        ) -> OptionalValue<super::AggregatorResultAsMultiResult<Self::Api>>;
+    }
+}
+
+pub struct AggregatorResult<M: ManagedTypeApi> {
+    pub round_id: u32,
+    pub from_token_name: ManagedBuffer<M>,
+    pub to_token_name: ManagedBuffer<M>,
+    pub price: BigUint<M>,
+    pub decimals: u8,
+}
+
+impl<M: ManagedTypeApi> From<AggregatorResultAsMultiResult<M>> for AggregatorResult<M> {
+    fn from(multi_result: AggregatorResultAsMultiResult<M>) -> Self {
+        let (round_id, from_token_name, to_token_name, price, decimals) = multi_result.into_tuple();
+
+        AggregatorResult {
+            round_id,
+            from_token_name,
+            to_token_name,
+            price,
+            decimals,
+        }
+    }
+}
+
+#[elrond_wasm::module]
+pub trait PriceAggregatorModule {
+    #[only_owner]
+    #[endpoint(setPriceAggregatorAddress)]
+    fn set_price_aggregator_address(&self, address: ManagedAddress) {
+        require!(
+            self.blockchain().is_smart_contract(&address),
+            "Invalid price aggregator address"
+        );
+
+        self.price_aggregator_address().set(&address);
+    }
+
+    fn get_price_for_pair(
+        &self,
+        from_ticker: ManagedBuffer,
+        to_ticker: ManagedBuffer,
+    ) -> Option<BigUint> {
+        self.get_full_result_for_pair(from_ticker, to_ticker)
+            .map(|aggregator_result| aggregator_result.price)
+    }
+
+    fn get_full_result_for_pair(
+        &self,
+        from_ticker: ManagedBuffer,
+        to_ticker: ManagedBuffer,
+    ) -> Option<AggregatorResult<Self::Api>> {
+        let price_aggregator_address = self.price_aggregator_address().get();
+        if price_aggregator_address.is_zero() {
+            return None;
+        }
+
+        let result: OptionalValue<AggregatorResultAsMultiResult<Self::Api>> = self
+            .aggregator_proxy(price_aggregator_address)
+            .latest_price_feed_optional(from_ticker, to_ticker)
+            .execute_on_dest_context();
+
+        result
+            .into_option()
+            .map(|multi_result| AggregatorResult::from(multi_result))
+    }
+
+    #[proxy]
+    fn aggregator_proxy(&self, address: ManagedAddress)
+        -> price_aggregator_proxy::Proxy<Self::Api>;
+
+    #[view(getAggregatorAddress)]
+    #[storage_mapper("priceAggregatorAddress")]
+    fn price_aggregator_address(&self) -> SingleValueMapper<ManagedAddress>;
+}

--- a/savings-account/src/price_aggregator_proxy.rs
+++ b/savings-account/src/price_aggregator_proxy.rs
@@ -5,7 +5,7 @@ pub const DOLLAR_TICKER: &[u8] = b"USD";
 pub type AggregatorResultAsMultiResult<M> =
     MultiValue5<u32, ManagedBuffer<M>, ManagedBuffer<M>, BigUint<M>, u8>;
 
-mod price_aggregator_proxy {
+mod price_aggregator_proxy_def {
     elrond_wasm::imports!();
 
     #[elrond_wasm::proxy]
@@ -78,14 +78,14 @@ pub trait PriceAggregatorModule {
             .latest_price_feed_optional(from_ticker, to_ticker)
             .execute_on_dest_context();
 
-        result
-            .into_option()
-            .map(|multi_result| AggregatorResult::from(multi_result))
+        result.into_option().map(AggregatorResult::from)
     }
 
     #[proxy]
-    fn aggregator_proxy(&self, address: ManagedAddress)
-        -> price_aggregator_proxy::Proxy<Self::Api>;
+    fn aggregator_proxy(
+        &self,
+        address: ManagedAddress,
+    ) -> price_aggregator_proxy_def::Proxy<Self::Api>;
 
     #[view(getAggregatorAddress)]
     #[storage_mapper("priceAggregatorAddress")]

--- a/savings-account/src/staking_rewards.rs
+++ b/savings-account/src/staking_rewards.rs
@@ -258,11 +258,8 @@ pub trait StakingRewardsModule:
     // we do not check the caller here to save gas, as the DEX SC only allocates very little gas for this call
     #[payable("*")]
     #[endpoint]
-    fn receive_stablecoin_after_convert(
-        &self,
-        #[payment_token] payment_token: TokenIdentifier,
-        #[payment_amount] payment_amount: BigUint,
-    ) {
+    fn receive_stablecoin_after_convert(&self) {
+        let (payment_amount, payment_token) = self.call_value().payment_token_pair();
         let stablecoin_token_id = self.stablecoin_token_id().get();
         require!(
             payment_token == stablecoin_token_id,

--- a/savings-account/src/tokens.rs
+++ b/savings-account/src/tokens.rs
@@ -92,15 +92,7 @@ pub trait TokensModule {
     }
 
     fn create_tokens(&self, token_id: &TokenIdentifier, amount: &BigUint) -> u64 {
-        self.send().esdt_nft_create(
-            token_id,
-            amount,
-            &ManagedBuffer::new(),
-            &BigUint::zero(),
-            &ManagedBuffer::new(),
-            &(),
-            &ManagedVec::new(),
-        )
+        self.send().esdt_nft_create_compact(token_id, amount, &())
     }
 
     fn send_stablecoins(&self, to: &ManagedAddress, amount: &BigUint) {

--- a/savings-account/src/tokens.rs
+++ b/savings-account/src/tokens.rs
@@ -17,13 +17,10 @@ pub trait TokensModule {
     #[only_owner]
     #[payable("EGLD")]
     #[endpoint(issueLendToken)]
-    fn issue_lend_token(
-        &self,
-        #[payment_amount] payment_amount: BigUint,
-        token_name: ManagedBuffer,
-        num_decimals: usize,
-    ) {
+    fn issue_lend_token(&self, token_name: ManagedBuffer, num_decimals: usize) {
         require!(self.lend_token_id().is_empty(), "Lend token already issued");
+
+        let payment_amount = self.call_value().egld_value();
         self.issue_token(
             payment_amount,
             token_name,
@@ -36,16 +33,13 @@ pub trait TokensModule {
     #[only_owner]
     #[payable("EGLD")]
     #[endpoint(issueBorrowToken)]
-    fn issue_borrow_token(
-        &self,
-        #[payment_amount] payment_amount: BigUint,
-        token_name: ManagedBuffer,
-        num_decimals: usize,
-    ) {
+    fn issue_borrow_token(&self, token_name: ManagedBuffer, num_decimals: usize) {
         require!(
             self.borrow_token_id().is_empty(),
             "Borrow token already issued"
         );
+
+        let payment_amount = self.call_value().egld_value();
         self.issue_token(
             payment_amount,
             token_name,

--- a/savings-account/tests/test.rs
+++ b/savings-account/tests/test.rs
@@ -171,10 +171,7 @@ fn test_rewards_penalty() {
             0,
             &rust_biguint!(100_000),
             |sc| {
-                sc.lend(
-                    managed_token_id!(STABLECOIN_TOKEN_ID),
-                    managed_biguint!(100_000),
-                );
+                sc.lend();
             },
         )
         .assert_ok();
@@ -187,10 +184,7 @@ fn test_rewards_penalty() {
             0,
             &rust_biguint!(100_000),
             |sc| {
-                sc.lend(
-                    managed_token_id!(STABLECOIN_TOKEN_ID),
-                    managed_biguint!(100_000),
-                );
+                sc.lend();
             },
         )
         .assert_ok();
@@ -247,12 +241,7 @@ fn test_rewards_penalty() {
             1,
             &rust_biguint!(100_000),
             |sc| {
-                sc.lender_claim_rewards(
-                    managed_token_id!(LEND_TOKEN_ID),
-                    1,
-                    managed_biguint!(100_000),
-                    OptionalValue::None,
-                );
+                sc.lender_claim_rewards(OptionalValue::None);
             },
         )
         .assert_ok();
@@ -313,12 +302,7 @@ fn test_rewards_penalty() {
             2,
             &rust_biguint!(100_000),
             |sc| {
-                sc.lender_claim_rewards(
-                    managed_token_id!(LEND_TOKEN_ID),
-                    2,
-                    managed_biguint!(100_000),
-                    OptionalValue::None,
-                );
+                sc.lender_claim_rewards(OptionalValue::None);
             },
         )
         .assert_ok();

--- a/savings-account/tests/test.rs
+++ b/savings-account/tests/test.rs
@@ -1,6 +1,5 @@
-use elrond_wasm::types::{
-    Address, EsdtLocalRole, ManagedBuffer, OperationCompletionStatus, OptionalArg, SCResult,
-};
+use elrond_wasm::elrond_codec::multi_types::OptionalValue;
+use elrond_wasm::types::{Address, EsdtLocalRole, ManagedBuffer, OperationCompletionStatus};
 use elrond_wasm_debug::{
     managed_address, managed_biguint, managed_token_id, rust_biguint, testing_framework::*,
     DebugApi,
@@ -26,8 +25,7 @@ const BORROW_TOKEN_ID: &[u8] = b"BORROW-123456";
 
 struct SavingsAccountSetup<SavingsAccountObjBuilder>
 where
-    SavingsAccountObjBuilder:
-        'static + Copy + Fn(DebugApi) -> savings_account::ContractObj<DebugApi>,
+    SavingsAccountObjBuilder: 'static + Copy + Fn() -> savings_account::ContractObj<DebugApi>,
 {
     pub blockchain_wrapper: BlockchainStateWrapper,
     pub owner_address: Address,
@@ -43,8 +41,7 @@ fn setup_savings_account<SavingsAccountObjBuilder>(
     sa_builder: SavingsAccountObjBuilder,
 ) -> SavingsAccountSetup<SavingsAccountObjBuilder>
 where
-    SavingsAccountObjBuilder:
-        'static + Copy + Fn(DebugApi) -> savings_account::ContractObj<DebugApi>,
+    SavingsAccountObjBuilder: 'static + Copy + Fn() -> savings_account::ContractObj<DebugApi>,
 {
     let rust_zero = rust_biguint!(0u64);
     let mut blockchain_wrapper = BlockchainStateWrapper::new();
@@ -111,30 +108,29 @@ where
         &(),
     );
 
-    blockchain_wrapper.execute_tx(&owner_address, &sa_wrapper, &rust_zero, |sc| {
-        let result = sc.init(
-            managed_token_id!(STABLECOIN_TOKEN_ID),
-            managed_token_id!(LIQUID_STAKING_TOKEN_ID),
-            managed_token_id!(STAKED_TOKEN_ID),
-            ManagedBuffer::new_from_bytes(STAKED_TOKEN_TICKER),
-            managed_address!(delegation_wrapper.address_ref()),
-            managed_address!(dex_wrapper.address_ref()),
-            managed_address!(price_aggregator_wrapper.address_ref()),
-            managed_biguint!(LOAN_TO_VALUE_PERCENTAGE),
-            managed_biguint!(LENDER_REWARDS_PERCENTAGE_PER_EPOCH),
-            managed_biguint!(BASE_BORROW_RATE),
-            managed_biguint!(BORROW_RATE_UNDER_OPTIMAL_FACTOR),
-            managed_biguint!(BORROW_RATE_OVER_OPTIMAL_FACTOR),
-            managed_biguint!(OPTIMAL_UTILISATION),
-        );
-        unwrap_or_panic(result);
+    blockchain_wrapper
+        .execute_tx(&owner_address, &sa_wrapper, &rust_zero, |sc| {
+            sc.init(
+                managed_token_id!(STABLECOIN_TOKEN_ID),
+                managed_token_id!(LIQUID_STAKING_TOKEN_ID),
+                managed_token_id!(STAKED_TOKEN_ID),
+                ManagedBuffer::new_from_bytes(STAKED_TOKEN_TICKER),
+                managed_address!(delegation_wrapper.address_ref()),
+                managed_address!(dex_wrapper.address_ref()),
+                managed_address!(price_aggregator_wrapper.address_ref()),
+                managed_biguint!(LOAN_TO_VALUE_PERCENTAGE),
+                managed_biguint!(LENDER_REWARDS_PERCENTAGE_PER_EPOCH),
+                managed_biguint!(BASE_BORROW_RATE),
+                managed_biguint!(BORROW_RATE_UNDER_OPTIMAL_FACTOR),
+                managed_biguint!(BORROW_RATE_OVER_OPTIMAL_FACTOR),
+                managed_biguint!(OPTIMAL_UTILISATION),
+            );
 
-        sc.lend_token_id().set(&managed_token_id!(LEND_TOKEN_ID));
-        sc.borrow_token_id()
-            .set(&managed_token_id!(BORROW_TOKEN_ID));
-
-        StateChange::Commit
-    });
+            sc.lend_token_id().set(&managed_token_id!(LEND_TOKEN_ID));
+            sc.borrow_token_id()
+                .set(&managed_token_id!(BORROW_TOKEN_ID));
+        })
+        .assert_ok();
 
     let roles = [
         EsdtLocalRole::NftCreate,
@@ -155,16 +151,6 @@ where
     }
 }
 
-fn unwrap_or_panic<T>(result: SCResult<T>) -> T {
-    match result {
-        SCResult::Ok(t) => t,
-        SCResult::Err(err) => {
-            let str = String::from_utf8(err.as_bytes().to_vec()).unwrap();
-            panic!("{}", str);
-        }
-    }
-}
-
 #[test]
 fn init_test() {
     let _ = setup_savings_account(savings_account::contract_obj);
@@ -177,101 +163,99 @@ fn test_rewards_penalty() {
 
     b_wrapper.set_block_epoch(20);
 
-    b_wrapper.execute_esdt_transfer(
-        &sa_setup.first_lender_address,
-        &sa_setup.sa_wrapper,
-        STABLECOIN_TOKEN_ID,
-        0,
-        &rust_biguint!(100_000),
-        |sc| {
-            let result = sc.lend(
-                managed_token_id!(STABLECOIN_TOKEN_ID),
-                managed_biguint!(100_000),
-            );
-            unwrap_or_panic(result);
+    b_wrapper
+        .execute_esdt_transfer(
+            &sa_setup.first_lender_address,
+            &sa_setup.sa_wrapper,
+            STABLECOIN_TOKEN_ID,
+            0,
+            &rust_biguint!(100_000),
+            |sc| {
+                sc.lend(
+                    managed_token_id!(STABLECOIN_TOKEN_ID),
+                    managed_biguint!(100_000),
+                );
+            },
+        )
+        .assert_ok();
 
-            StateChange::Commit
-        },
-    );
-
-    b_wrapper.execute_esdt_transfer(
-        &sa_setup.second_lender_address,
-        &sa_setup.sa_wrapper,
-        STABLECOIN_TOKEN_ID,
-        0,
-        &rust_biguint!(100_000),
-        |sc| {
-            let result = sc.lend(
-                managed_token_id!(STABLECOIN_TOKEN_ID),
-                managed_biguint!(100_000),
-            );
-            unwrap_or_panic(result);
-
-            StateChange::Commit
-        },
-    );
+    b_wrapper
+        .execute_esdt_transfer(
+            &sa_setup.second_lender_address,
+            &sa_setup.sa_wrapper,
+            STABLECOIN_TOKEN_ID,
+            0,
+            &rust_biguint!(100_000),
+            |sc| {
+                sc.lend(
+                    managed_token_id!(STABLECOIN_TOKEN_ID),
+                    managed_biguint!(100_000),
+                );
+            },
+        )
+        .assert_ok();
 
     b_wrapper.set_block_epoch(25);
 
     // set state required for calculate rewards to be callable
-    b_wrapper.execute_tx(
-        &sa_setup.owner_address,
-        &sa_setup.sa_wrapper,
-        &rust_biguint!(0),
-        |sc| {
-            sc.last_staking_rewards_claim_epoch().set(&25);
-            sc.last_staking_token_convert_epoch().set(&25);
-            sc.stablecoin_reserves().set(&managed_biguint!(500));
+    b_wrapper
+        .execute_tx(
+            &sa_setup.owner_address,
+            &sa_setup.sa_wrapper,
+            &rust_biguint!(0),
+            |sc| {
+                sc.last_staking_rewards_claim_epoch().set(&25);
+                sc.last_staking_token_convert_epoch().set(&25);
+                sc.stablecoin_reserves().set(&managed_biguint!(500));
+            },
+        )
+        .assert_ok();
 
-            StateChange::Commit
-        },
-    );
-
-    b_wrapper.execute_tx(
-        &sa_setup.owner_address,
-        &sa_setup.sa_wrapper,
-        &rust_biguint!(0),
-        |sc| {
-            let result = sc.calculate_total_lender_rewards();
-            let op_status = unwrap_or_panic(result);
-            assert_eq!(op_status, OperationCompletionStatus::Completed);
-
-            StateChange::Commit
-        },
-    );
+    b_wrapper
+        .execute_tx(
+            &sa_setup.owner_address,
+            &sa_setup.sa_wrapper,
+            &rust_biguint!(0),
+            |sc| {
+                let op_status = sc.calculate_total_lender_rewards();
+                assert_eq!(op_status, OperationCompletionStatus::Completed);
+            },
+        )
+        .assert_ok();
 
     // expected rewards is 0.5% * 100_000 * (5 epochs) = 2.5% * 100_000 = 2_500 per lender
     // i.e. 5_000 total rewards
-    b_wrapper.execute_query(&sa_setup.sa_wrapper, |sc| {
-        let unclaimed_rewards = sc.unclaimed_rewards().get();
-        assert_eq!(unclaimed_rewards, managed_biguint!(500));
+    b_wrapper
+        .execute_query(&sa_setup.sa_wrapper, |sc| {
+            let unclaimed_rewards = sc.unclaimed_rewards().get();
+            assert_eq!(unclaimed_rewards, managed_biguint!(500));
 
-        let missing_rewards = sc.missing_rewards().get();
-        assert_eq!(missing_rewards, managed_biguint!(4_500));
+            let missing_rewards = sc.missing_rewards().get();
+            assert_eq!(missing_rewards, managed_biguint!(4_500));
 
-        let penalty_per_lender = sc.penalty_amount_per_lender().get();
-        assert_eq!(penalty_per_lender, managed_biguint!(2_250));
-    });
+            let penalty_per_lender = sc.penalty_amount_per_lender().get();
+            assert_eq!(penalty_per_lender, managed_biguint!(2_250));
+        })
+        .assert_ok();
 
     // lender 1 claim, should claim 2_500 - 2_250 = 250
-    b_wrapper.execute_esdt_transfer(
-        &sa_setup.first_lender_address,
-        &sa_setup.sa_wrapper,
-        LEND_TOKEN_ID,
-        1,
-        &rust_biguint!(100_000),
-        |sc| {
-            let result = sc.lender_claim_rewards(
-                managed_token_id!(LEND_TOKEN_ID),
-                1,
-                managed_biguint!(100_000),
-                OptionalArg::None,
-            );
-            unwrap_or_panic(result);
-
-            StateChange::Commit
-        },
-    );
+    b_wrapper
+        .execute_esdt_transfer(
+            &sa_setup.first_lender_address,
+            &sa_setup.sa_wrapper,
+            LEND_TOKEN_ID,
+            1,
+            &rust_biguint!(100_000),
+            |sc| {
+                sc.lender_claim_rewards(
+                    managed_token_id!(LEND_TOKEN_ID),
+                    1,
+                    managed_biguint!(100_000),
+                    OptionalValue::None,
+                );
+            },
+        )
+        .assert_ok();
 
     b_wrapper.check_esdt_balance(
         &sa_setup.first_lender_address,
@@ -282,62 +266,62 @@ fn test_rewards_penalty() {
     // assume lender2 waited and claimed rewards later, when penalty was lifted
     b_wrapper.set_block_epoch(26);
 
-    b_wrapper.execute_tx(
-        &sa_setup.owner_address,
-        &sa_setup.sa_wrapper,
-        &rust_biguint!(0),
-        |sc| {
-            sc.last_staking_rewards_claim_epoch().set(&26);
-            sc.last_staking_token_convert_epoch().set(&26);
-            sc.stablecoin_reserves().set(&managed_biguint!(10_000));
+    b_wrapper
+        .execute_tx(
+            &sa_setup.owner_address,
+            &sa_setup.sa_wrapper,
+            &rust_biguint!(0),
+            |sc| {
+                sc.last_staking_rewards_claim_epoch().set(&26);
+                sc.last_staking_token_convert_epoch().set(&26);
+                sc.stablecoin_reserves().set(&managed_biguint!(10_000));
+            },
+        )
+        .assert_ok();
 
-            StateChange::Commit
-        },
-    );
+    b_wrapper
+        .execute_tx(
+            &sa_setup.owner_address,
+            &sa_setup.sa_wrapper,
+            &rust_biguint!(0),
+            |sc| {
+                let op_status = sc.calculate_total_lender_rewards();
+                assert_eq!(op_status, OperationCompletionStatus::Completed);
+            },
+        )
+        .assert_ok();
 
-    b_wrapper.execute_tx(
-        &sa_setup.owner_address,
-        &sa_setup.sa_wrapper,
-        &rust_biguint!(0),
-        |sc| {
-            let result = sc.calculate_total_lender_rewards();
-            let op_status = unwrap_or_panic(result);
-            assert_eq!(op_status, OperationCompletionStatus::Completed);
+    b_wrapper
+        .execute_query(&sa_setup.sa_wrapper, |sc| {
+            let unclaimed_rewards = sc.unclaimed_rewards().get();
+            assert_eq!(unclaimed_rewards, managed_biguint!(3_500));
 
-            StateChange::Commit
-        },
-    );
+            let missing_rewards = sc.missing_rewards().get();
+            assert_eq!(missing_rewards, managed_biguint!(0));
 
-    b_wrapper.execute_query(&sa_setup.sa_wrapper, |sc| {
-        let unclaimed_rewards = sc.unclaimed_rewards().get();
-        assert_eq!(unclaimed_rewards, managed_biguint!(3_500));
-
-        let missing_rewards = sc.missing_rewards().get();
-        assert_eq!(missing_rewards, managed_biguint!(0));
-
-        let penalty_per_lender = sc.penalty_amount_per_lender().get();
-        assert_eq!(penalty_per_lender, managed_biguint!(0));
-    });
+            let penalty_per_lender = sc.penalty_amount_per_lender().get();
+            assert_eq!(penalty_per_lender, managed_biguint!(0));
+        })
+        .assert_ok();
 
     // lender 2 claim, will get the full amount of 3_000
-    b_wrapper.execute_esdt_transfer(
-        &sa_setup.second_lender_address,
-        &sa_setup.sa_wrapper,
-        LEND_TOKEN_ID,
-        2,
-        &rust_biguint!(100_000),
-        |sc| {
-            let result = sc.lender_claim_rewards(
-                managed_token_id!(LEND_TOKEN_ID),
-                2,
-                managed_biguint!(100_000),
-                OptionalArg::None,
-            );
-            unwrap_or_panic(result);
-
-            StateChange::Commit
-        },
-    );
+    b_wrapper
+        .execute_esdt_transfer(
+            &sa_setup.second_lender_address,
+            &sa_setup.sa_wrapper,
+            LEND_TOKEN_ID,
+            2,
+            &rust_biguint!(100_000),
+            |sc| {
+                sc.lender_claim_rewards(
+                    managed_token_id!(LEND_TOKEN_ID),
+                    2,
+                    managed_biguint!(100_000),
+                    OptionalValue::None,
+                );
+            },
+        )
+        .assert_ok();
 
     b_wrapper.check_esdt_balance(
         &sa_setup.second_lender_address,

--- a/savings-account/wasm/Cargo.toml
+++ b/savings-account/wasm/Cargo.toml
@@ -21,9 +21,9 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.25.0"
+version = "0.30.0"
 features = [ "vm-validate-token-identifier" ]
 
 [dependencies.elrond-wasm-output]
-version = "0.25.0"
+version = "0.30.0"
 features = ["wasm-output-mode"]

--- a/savings-account/wasm/src/lib.rs
+++ b/savings-account/wasm/src/lib.rs
@@ -36,7 +36,6 @@ elrond_wasm_node::wasm_endpoints! {
         lend
         lenderClaimRewards
         receiveStakingRewards
-        receive_stablecoin_after_convert
         repay
         setPriceAggregatorAddress
         withdraw

--- a/savings-account/wasm/src/lib.rs
+++ b/savings-account/wasm/src/lib.rs
@@ -7,7 +7,6 @@
 elrond_wasm_node::wasm_endpoints! {
     savings_account
     (
-        init
         callBack
         borrow
         calculateTotalLenderRewards
@@ -27,6 +26,7 @@ elrond_wasm_node::wasm_endpoints! {
         getLenderRewardsPercentagePerEpoch
         getLiquidStakingTokenId
         getLoadToValuePercentage
+        getPenaltyAmountPerLender
         getStablecoinReserves
         getStablecoinTokenId
         getStakedTokenId
@@ -38,8 +38,6 @@ elrond_wasm_node::wasm_endpoints! {
         receiveStakingRewards
         receive_stablecoin_after_convert
         repay
-        setBorrowTokenRoles
-        setLendTokenRoles
         setPriceAggregatorAddress
         withdraw
     )


### PR DESCRIPTION
- upgrade to elrond-wasm 0.30 version (also removing SCResult and #[payment] annotations)
- copy price aggregator proxy instead of importing it from another repo (less maintenance needed for future upgrades)
- use the new issue & set all roles function instead of having two endpoints for each token (lend/borrow)
- change pair swap call from async call to sync
- general code improvements for both performance and readability