### PR TITLE
rework penalties to be percentage based

### DIFF
--- a/savings-account/mandos/borrow.scen.json
+++ b/savings-account/mandos/borrow.scen.json
@@ -115,8 +115,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -124,7 +123,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "18,750",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -135,8 +133,6 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:1"
                         },
-                        
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/calculate-rewards-one-call.json
+++ b/savings-account/mandos/calculate-rewards-one-call.json
@@ -21,7 +21,10 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "5", "6", "7", "8",
+                    "5",
+                    "6",
+                    "7",
+                    "8",
                     "str:completed"
                 ],
                 "gas": "*",
@@ -115,8 +118,7 @@
                             "1-lend_epoch": "u64:21",
                             "2-amount_in_circulation": "biguint:50,000"
                         },
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -142,7 +144,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "75,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -168,9 +169,7 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:stablecoinReserves": "6,500",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/lend.scen.json
+++ b/savings-account/mandos/lend.scen.json
@@ -84,8 +84,7 @@
                             "1-lend_epoch": "u64:20",
                             "2-amount_in_circulation": "biguint:100,000"
                         },
-                        "str:lendedAmount": "100,000",
-                        "str:nrLenders": "1",
+                        "str:lentAmount": "100,000",
                         "+": ""
                     },
                     "owner": "address:owner",
@@ -223,8 +222,7 @@
                             "1-lend_epoch": "u64:21",
                             "2-amount_in_circulation": "biguint:50,000"
                         },
-                        "str:lendedAmount": "150,000",
-                        "str:nrLenders": "2",
+                        "str:lentAmount": "150,000",
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/lender-claim-after-multiple-borrows.json
+++ b/savings-account/mandos/lender-claim-after-multiple-borrows.json
@@ -8,25 +8,86 @@
             }
         },
         {
-            "step": "scQuery",
-            "txId": "get-penalty-amount",
+            "step": "scCall",
+            "comment": "100,000 out of total 150,000 => ~66% of 12,250. Called as endpoint instead of query for the check state after",
             "tx": {
+                "from": "address:lender1",
                 "to": "sc:savings_account",
-                "function": "getPenaltyAmountPerLender",
-                "arguments": []
+                "value": "0",
+                "function": "getPenaltyAmount",
+                "arguments": [
+                    "100,000"
+                ],
+                "gasLimit": "50,000,000",
+                "gasPrice": "0"
             },
             "expect": {
+                "status": "0",
+                "message": "",
                 "out": [
-                    "6,125"
+                    "8,166"
                 ],
                 "gas": "*",
                 "refund": "*"
             }
         },
         {
+            "step": "checkState",
+            "accounts": {
+                "address:lender1": {
+                    "nonce": "*",
+                    "balance": "0",
+                    "esdt": {
+                        "str:STABLE-123456": "0",
+                        "str:LEND-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "100,000",
+                                    "creator": "sc:savings_account"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "address:lender2": {
+                    "nonce": "*",
+                    "balance": "0",
+                    "esdt": {
+                        "str:STABLE-123456": "50,000",
+                        "str:LEND-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "2",
+                                    "balance": "50,000",
+                                    "creator": "sc:savings_account"
+                                }
+                            ]
+                        }
+                    },
+                    "storage": {}
+                },
+                "sc:savings_account": {
+                    "nonce": "0",
+                    "balance": "0",
+                    "esdt": "*",
+                    "storage": {
+                        "str:lentAmount": "150,000",
+                        "str:stablecoinReserves": "0",
+                        "str:missingRewards": "12,250",
+                        "str:penaltyPerLendToken": "81,666,666,666,666,667",
+                        "+": ""
+                    },
+                    "code": "file:../output/savings-account.wasm"
+                },
+                "+": {}
+            }
+        },
+        {
             "step": "scQuery",
             "txId": "get-lender-claimable-rewards-1",
-            "comment": "(50 - 20) * 0.5% * 100,000 - 6,125 = 15,000 - 6,125 = 8,875",
+            "comment": "(50 - 20) * 0.5% * 100,000 - 6,125 = 15,000 - 8,166 = 6,834",
             "tx": {
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
@@ -37,14 +98,14 @@
             },
             "expect": {
                 "out": [
-                    "8,875"
+                    "6,834"
                 ]
             }
         },
         {
             "step": "scQuery",
             "txId": "get-lender-claimable-rewards-2",
-            "comment": "(50 - 21) * 0.5% * 50,000 - 6,125 = 7,250 - 6,125 = 1,125",
+            "comment": "(50 - 21) * 0.5% * 50,000 - 4,083 = 7,250 - 4,083 = 3,167",
             "tx": {
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
@@ -55,7 +116,7 @@
             },
             "expect": {
                 "out": [
-                    "1,125"
+                    "3,167"
                 ]
             }
         },
@@ -120,7 +181,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "8,875",
+                        "str:STABLE-123456": "6,834",
                         "str:LEND-123456": {
                             "instances": [
                                 {
@@ -137,7 +198,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "54,187",
+                        "str:STABLE-123456": "53,167",
                         "str:LEND-123456": {
                             "instances": [
                                 {
@@ -154,7 +215,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "71,938",
+                        "str:STABLE-123456": "74,999",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -209,8 +270,7 @@
                             "1-lend_epoch": "u64:50",
                             "2-amount_in_circulation": "biguint:50,000"
                         },
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -236,7 +296,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "75,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -262,15 +321,12 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:lastStakingRewardsClaimEpoch": "25",
                         "str:lastStakingTokenConvertEpoch": "25",
                         "str:lastRewardsUpdateEpoch": "50",
-
-                        "str:unclaimedRewards": "0",
                         "str:stablecoinReserves": "0",
-                        "str:missingRewards": "3,062",
-
+                        "str:missingRewards": "1",
+                        "str:totalMissedRewardsByClaimSinceLastCalculation": "12,249",
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/more-borrows.scen.json
+++ b/savings-account/mandos/more-borrows.scen.json
@@ -212,7 +212,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "75,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -238,7 +237,6 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:4"
                         },
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/repay-full.scen.json
+++ b/savings-account/mandos/repay-full.scen.json
@@ -157,7 +157,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "111,104",
+                        "str:STABLE-123456": "114,165",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -197,8 +197,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": "",
                         "str:borrowMetadata|u64:2": {
                             "1-staking_position_id": "u64:2",
@@ -219,7 +218,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "50,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:2",
@@ -240,9 +238,7 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:stablecoinReserves": "14,166",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/repay-last-pos-full.scen.json
+++ b/savings-account/mandos/repay-last-pos-full.scen.json
@@ -93,7 +93,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "111,104",
+                        "str:STABLE-123456": "114,165",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -133,8 +133,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -155,7 +154,6 @@
                         },
                         "str:borrowMetadata|u64:4": "",
                         "str:borrowedAmount": "50,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -177,9 +175,7 @@
                             "3-liquid_staking_nonce": "u64:7"
                         },
                         "str:stakingPosition|u64:4": "",
-
                         "str:stablecoinReserves": "14,166",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/repay-other-pos-full.scen.json
+++ b/savings-account/mandos/repay-other-pos-full.scen.json
@@ -93,7 +93,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "111,104",
+                        "str:STABLE-123456": "114,165",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -133,8 +133,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -155,7 +154,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "50,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -177,9 +175,7 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:stablecoinReserves": "14,166",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/repay-partial.scen.json
+++ b/savings-account/mandos/repay-partial.scen.json
@@ -97,7 +97,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "95,437",
+                        "str:STABLE-123456": "98,498",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -142,8 +142,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -169,7 +168,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "60,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -195,9 +193,7 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:stablecoinReserves": "8,499",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"
@@ -285,7 +281,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "110,970",
+                        "str:STABLE-123456": "114,031",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -325,8 +321,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:borrowMetadata|u64:1": "",
                         "str:borrowMetadata|u64:2": {
                             "1-staking_position_id": "u64:2",
@@ -347,7 +342,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "50,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:2",
@@ -368,9 +362,7 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:stablecoinReserves": "14,032",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/rewards-with-one-borrow.scen.json
+++ b/savings-account/mandos/rewards-with-one-borrow.scen.json
@@ -81,10 +81,8 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:5"
                         },
-
                         "str:lastStakingRewardsClaimEpoch": "23",
                         "str:currentOngoingOperation": "",
-                        
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"
@@ -166,13 +164,10 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:5"
                         },
-
                         "str:lastStakingRewardsClaimEpoch": "23",
                         "str:lastStakingTokenConvertEpoch": "23",
                         "str:currentOngoingOperation": "",
-
                         "str:stablecoinReserves": "500",
-                        
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"
@@ -312,10 +307,8 @@
                             "1-lend_epoch": "u64:23",
                             "2-amount_in_circulation": "biguint:50,000"
                         },
-
-                        "str:lendedAmount": "150,000",
+                        "str:lentAmount": "150,000",
                         "str:stablecoinReserves": "500",
-                        
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"
@@ -501,11 +494,9 @@
                             "1-lend_epoch": "u64:23",
                             "2-amount_in_circulation": "biguint:50,000"
                         },
-                        "str:lendedAmount": "150,000",
-
+                        "str:lentAmount": "150,000",
                         "str:unclaimedRewards": "0",
                         "str:stablecoinReserves": "500",
-                        
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/withdraw-with-rewards-full.scen.json
+++ b/savings-account/mandos/withdraw-with-rewards-full.scen.json
@@ -24,7 +24,7 @@
             },
             "expect": {
                 "out": [
-                    "1,125"
+                    "3,167"
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -123,8 +123,7 @@
                             "2-amount_in_circulation": "biguint:100,000"
                         },
                         "str:lendMetadata|u64:2": "",
-                        "str:lendedAmount": "100,000",
-
+                        "str:lentAmount": "100,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -150,7 +149,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "75,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -176,13 +174,10 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:lastStakingRewardsClaimEpoch": "25",
                         "str:lastStakingTokenConvertEpoch": "25",
                         "str:lastRewardsUpdateEpoch": "50",
-
                         "str:stablecoinReserves": "0",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/mandos/withdraw-with-rewards-partial.scen.json
+++ b/savings-account/mandos/withdraw-with-rewards-partial.scen.json
@@ -24,7 +24,7 @@
             },
             "expect": {
                 "out": [
-                    "1,125"
+                    "3,167"
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -87,7 +87,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "100,000",
+                        "str:STABLE-123456": "101,584",
                         "str:LEND-123456": {
                             "instances": []
                         }
@@ -98,7 +98,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "35,000",
+                        "str:STABLE-123456": "33,416",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -148,8 +148,7 @@
                             "2-amount_in_circulation": "biguint:100,000"
                         },
                         "str:lendMetadata|u64:2": "",
-                        "str:lendedAmount": "100,000",
-
+                        "str:lentAmount": "100,000",
                         "str:borrowMetadata|u64:1": {
                             "1-staking_position_id": "u64:1",
                             "2-borrow_epoch": "u64:25",
@@ -175,7 +174,6 @@
                             "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
                         },
                         "str:borrowedAmount": "75,000",
-
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
                             "2-next_pos_id": "u64:1",
@@ -201,13 +199,10 @@
                             "2-next_pos_id": "u64:0",
                             "3-liquid_staking_nonce": "u64:8"
                         },
-
                         "str:lastStakingRewardsClaimEpoch": "25",
                         "str:lastStakingTokenConvertEpoch": "25",
                         "str:lastRewardsUpdateEpoch": "50",
-
                         "str:stablecoinReserves": "0",
-
                         "+": ""
                     },
                     "code": "file:../output/savings-account.wasm"

--- a/savings-account/src/common_storage.rs
+++ b/savings-account/src/common_storage.rs
@@ -6,12 +6,9 @@ pub trait CommonStorageModule {
     #[storage_mapper("stablecoinReserves")]
     fn stablecoin_reserves(&self) -> SingleValueMapper<BigUint>;
 
-    #[storage_mapper("nrLenders")]
-    fn nr_lenders(&self) -> SingleValueMapper<u64>;
-
-    #[view(getLendedAmount)]
-    #[storage_mapper("lendedAmount")]
-    fn lended_amount(&self) -> SingleValueMapper<BigUint>;
+    #[view(getLentAmount)]
+    #[storage_mapper("lentAmount")]
+    fn lent_amount(&self) -> SingleValueMapper<BigUint>;
 
     #[view(getBorowedAmount)]
     #[storage_mapper("borrowedAmount")]

--- a/savings-account/src/math.rs
+++ b/savings-account/src/math.rs
@@ -1,7 +1,7 @@
 elrond_wasm::imports!();
 
-const BASE_PRECISION: u32 = 1_000_000_000; // Could be reduced maybe? Since we're working with epochs instead of seconds
-const DEFAULT_DECIMALS: u64 = 1_000_000_000_000_000_000; // most tokens have 10^18 decimals. TODO: Add as configurable value
+pub const BASE_PRECISION: u32 = 1_000_000_000; // Could be reduced maybe? Since we're working with epochs instead of seconds
+pub const DEFAULT_DECIMALS: u64 = 1_000_000_000_000_000_000; // most tokens have 10^18 decimals. TODO: Add as configurable value
 const EPOCHS_IN_YEAR: u32 = 365;
 
 #[elrond_wasm::module]

--- a/savings-account/src/tokens.rs
+++ b/savings-account/src/tokens.rs
@@ -121,12 +121,15 @@ pub trait TokensModule {
     fn lend_token(&self) -> NonFungibleTokenMapper<Self::Api>;
 
     #[storage_mapper("lendMetadata")]
-    fn lend_metadata(&self, sft_nonce: u64) -> SingleValueMapper<LendMetadata<Self::Api>>;
+    fn lend_metadata(&self, lend_token_nonce: u64) -> SingleValueMapper<LendMetadata<Self::Api>>;
 
     #[view(getBorrowTokenId)]
     #[storage_mapper("borrowTokenId")]
     fn borrow_token(&self) -> NonFungibleTokenMapper<Self::Api>;
 
     #[storage_mapper("borrowMetadata")]
-    fn borrow_metadata(&self, sft_nonce: u64) -> SingleValueMapper<BorrowMetadata<Self::Api>>;
+    fn borrow_metadata(
+        &self,
+        borrow_token_nonce: u64,
+    ) -> SingleValueMapper<BorrowMetadata<Self::Api>>;
 }

--- a/savings-account/wasm/src/lib.rs
+++ b/savings-account/wasm/src/lib.rs
@@ -19,12 +19,12 @@ elrond_wasm_node::wasm_endpoints! {
         getLastStakingRewardsClaimEpoch
         getLastStakingTokenConvertEpoch
         getLendTokenId
-        getLendedAmount
         getLenderClaimableRewards
         getLenderRewardsPercentagePerEpoch
+        getLentAmount
         getLiquidStakingTokenId
         getLoadToValuePercentage
-        getPenaltyAmountPerLender
+        getPenaltyAmount
         getStablecoinReserves
         getStablecoinTokenId
         getStakedTokenId


### PR DESCRIPTION
Previously, penalties were a fixed amount for everyone. This had a few problems:
- it's very difficult to determine the actual number of lenders. Partial SFT positions make this very tricky
- it's not fair for the lenders with low amounts, as they likely won't be able to ever claim their rewards

Additionally:
- renamed `lended_amount` to `lent_amount` (since apparently "lended" is not a word...)