### PR TITLE
Metadata in tokens

### DIFF
--- a/delegation-mock/Cargo.toml
+++ b/delegation-mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"

--- a/delegation-mock/mandos/init.scen.json
+++ b/delegation-mock/mandos/init.scen.json
@@ -95,9 +95,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "1"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -117,9 +115,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "2"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -139,9 +135,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "3"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -161,9 +155,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    "4"
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }

--- a/delegation-mock/meta/Cargo.toml
+++ b/delegation-mock/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"

--- a/delegation-mock/src/lib.rs
+++ b/delegation-mock/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use elrond_wasm::elrond_codec::Empty;
+
 elrond_wasm::imports!();
 
 #[elrond_wasm::contract]
@@ -37,7 +39,7 @@ pub trait DelegationMock {
     fn claim_rewards(
         &self,
         #[payment_multi] payments: ManagedVec<EsdtTokenPayment<Self::Api>>,
-        #[var_args] opt_receive_funds_func: OptionalValue<ManagedBuffer>,
+        opt_receive_funds_func: OptionalValue<ManagedBuffer>,
     ) {
         let liquid_staking_token_id = self.liquid_staking_token_id().get();
 
@@ -99,7 +101,7 @@ pub trait DelegationMock {
             &ManagedBuffer::new(),
             &BigUint::zero(),
             &ManagedBuffer::new(),
-            &(),
+            &Empty,
             &ManagedVec::new(),
         )
     }

--- a/delegation-mock/wasm/Cargo.toml
+++ b/delegation-mock/wasm/Cargo.toml
@@ -21,9 +21,9 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.30.0"
+version = "0.31.1"
 features = [ "vm-validate-token-identifier" ]
 
 [dependencies.elrond-wasm-output]
-version = "0.30.0"
+version = "0.31.1"
 features = [ "wasm-output-mode" ]

--- a/dex-mock/Cargo.toml
+++ b/dex-mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"

--- a/dex-mock/meta/Cargo.toml
+++ b/dex-mock/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"

--- a/dex-mock/src/lib.rs
+++ b/dex-mock/src/lib.rs
@@ -22,7 +22,7 @@ pub trait DexMock {
         #[payment_amount] amount_in: BigUint,
         token_out: TokenIdentifier,
         _amount_out_min: BigUint,
-        #[var_args] opt_accept_funds_func: OptionalValue<ManagedBuffer>,
+        opt_accept_funds_func: OptionalValue<ManagedBuffer>,
     ) -> EsdtTokenPayment<Self::Api> {
         let caller = self.blockchain().get_caller();
         let amount_out = amount_in * 100u64 / EGLD_DECIMALS;

--- a/dex-mock/wasm/Cargo.toml
+++ b/dex-mock/wasm/Cargo.toml
@@ -21,8 +21,8 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.30.0"
+version = "0.31.1"
 
 [dependencies.elrond-wasm-output]
-version = "0.30.0"
+version = "0.31.1"
 features = ["wasm-output-mode"]

--- a/savings-account/Cargo.toml
+++ b/savings-account/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dependencies.elrond-wasm-modules]
-version = "0.30.0"
+version = "0.31.1"
 
 [dev-dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"
 
 [dev-dependencies]
 num-bigint = "0.4.2"

--- a/savings-account/mandos/borrow.scen.json
+++ b/savings-account/mandos/borrow.scen.json
@@ -32,12 +32,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0",
-                    "1"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:BORROW-123456",
+                        "3-token_nonce": "u64:1",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:18,750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -56,7 +62,12 @@
                                 {
                                     "nonce": "1",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:1",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -102,6 +113,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -116,12 +145,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "18,750",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/calculate-rewards-one-call.json
+++ b/savings-account/mandos/calculate-rewards-one-call.json
@@ -21,10 +21,6 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "5",
-                    "6",
-                    "7",
-                    "8",
                     "str:completed"
                 ],
                 "gas": "*",
@@ -46,14 +42,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    {
-                        "1-token-type": "u8:0",
-                        "2-token_id": "nested:str:STABLE-123456",
-                        "3-token_nonce": "u64:0",
-                        "4-amount": "biguint:10,000"
-                    }
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -97,6 +86,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -110,39 +117,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
-                        "str:lendMetadata|u64:2": {
-                            "1-lend_epoch": "u64:21",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "75,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/lend.scen.json
+++ b/savings-account/mandos/lend.scen.json
@@ -31,7 +31,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:1",
+                        "4-amount": "biguint:100,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -49,7 +54,10 @@
                                 {
                                     "nonce": "1",
                                     "balance": "100,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
                                 }
                             ]
                         }
@@ -68,6 +76,16 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                }
+                            ],
                             "lastNonce": "1"
                         },
                         "str:BORROW-123456": {
@@ -80,10 +98,6 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
                         "str:lentAmount": "100,000",
                         "+": ""
                     },
@@ -164,7 +178,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "2"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:2",
+                        "4-amount": "biguint:50,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -183,7 +202,10 @@
                                 {
                                     "nonce": "2",
                                     "balance": "50,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
                                 }
                             ]
                         }
@@ -202,6 +224,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -214,14 +254,6 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
-                        "str:lendMetadata|u64:2": {
-                            "1-lend_epoch": "u64:21",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
                         "str:lentAmount": "150,000",
                         "+": ""
                     },

--- a/savings-account/mandos/lender-claim-after-multiple-borrows.json
+++ b/savings-account/mandos/lender-claim-after-multiple-borrows.json
@@ -44,7 +44,10 @@
                                 {
                                     "nonce": "1",
                                     "balance": "100,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
                                 }
                             ]
                         }
@@ -61,7 +64,10 @@
                                 {
                                     "nonce": "2",
                                     "balance": "50,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
                                 }
                             ]
                         }
@@ -92,7 +98,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "1",
+                    "20",
                     "100,000"
                 ]
             },
@@ -110,7 +116,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "2",
+                    "21",
                     "50,000"
                 ]
             },
@@ -141,7 +147,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "3"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:100,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:6,834"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -168,7 +185,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "4"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:50,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:3,167"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -187,7 +215,10 @@
                                 {
                                     "nonce": "3",
                                     "balance": "100,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
                                 }
                             ]
                         }
@@ -202,9 +233,12 @@
                         "str:LEND-123456": {
                             "instances": [
                                 {
-                                    "nonce": "4",
+                                    "nonce": "3",
                                     "balance": "50,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
                                 }
                             ]
                         }
@@ -247,7 +281,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -260,41 +320,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": "",
-                        "str:lendMetadata|u64:2": "",
-                        "str:lendMetadata|u64:3": {
-                            "1-lend_epoch": "u64:50",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
-                        "str:lendMetadata|u64:4": {
-                            "1-lend_epoch": "u64:50",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "75,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/more-borrows.scen.json
+++ b/savings-account/mandos/more-borrows.scen.json
@@ -26,12 +26,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0",
-                    "2"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:BORROW-123456",
+                        "3-token_nonce": "u64:2",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:18,750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -58,12 +64,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0",
-                    "3"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:BORROW-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:18,750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -90,12 +102,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0",
-                    "4"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:BORROW-123456",
+                        "3-token_nonce": "u64:4",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:18,750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -114,22 +132,42 @@
                                 {
                                     "nonce": "1",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:1",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "3",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:3",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "4",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:4",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -174,6 +212,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -187,30 +243,6 @@
                         }
                     },
                     "storage": {
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "75,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/repay-full.scen.json
+++ b/savings-account/mandos/repay-full.scen.json
@@ -38,7 +38,7 @@
             },
             "expect": {
                 "status": "4",
-                "message": "str:First transfer must be the Stablecoins",
+                "message": "str:Must send exactly 2 types of tokens: Borrow SFTs and Stablecoins",
                 "out": [],
                 "gas": "*",
                 "refund": "*"
@@ -105,11 +105,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LIQ-123456",
+                        "3-token_nonce": "u64:5",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -128,17 +129,32 @@
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "3",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:3",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "4",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:4",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -184,7 +200,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -198,25 +240,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": "",
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "50,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/repay-last-pos-full.scen.json
+++ b/savings-account/mandos/repay-last-pos-full.scen.json
@@ -41,11 +41,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LIQ-123456",
+                        "3-token_nonce": "u64:8",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -64,17 +65,32 @@
                                 {
                                     "nonce": "1",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:1",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "3",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:3",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -120,7 +136,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -134,25 +176,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": "",
                         "str:borrowedAmount": "50,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/repay-other-pos-full.scen.json
+++ b/savings-account/mandos/repay-other-pos-full.scen.json
@@ -41,11 +41,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LIQ-123456",
+                        "3-token_nonce": "u64:7",
+                        "4-amount": "biguint:250,000,000,000,000,000,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -64,17 +65,32 @@
                                 {
                                     "nonce": "1",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:1",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "4",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:4",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -120,7 +136,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -134,25 +176,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": "",
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "50,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/repay-partial.scen.json
+++ b/savings-account/mandos/repay-partial.scen.json
@@ -40,11 +40,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LIQ-123456",
+                        "3-token_nonce": "u64:5",
+                        "4-amount": "biguint:150,000,000,000,000,000,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -63,22 +64,42 @@
                                 {
                                     "nonce": "1",
                                     "balance": "100,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:1",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "3",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:3",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "4",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:4",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -129,7 +150,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -143,30 +190,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:100,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "60,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",
@@ -229,11 +252,12 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "1",
-                    "str:EGLD",
-                    "str:USD",
-                    "100",
-                    "0"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LIQ-123456",
+                        "3-token_nonce": "u64:5",
+                        "4-amount": "biguint:100,000,000,000,000,000,000"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -252,17 +276,32 @@
                                 {
                                     "nonce": "2",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:2",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "3",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:3",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 },
                                 {
                                     "nonce": "4",
                                     "balance": "250,000,000,000,000,000,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-staking_position_id": "u64:4",
+                                        "2-borrow_epoch": "u64:25",
+                                        "3-staked_token_value_in_dollars_at_borrow": "biguint:100"
+                                    }
                                 }
                             ]
                         },
@@ -308,7 +347,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "4"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:50"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -322,25 +387,6 @@
                     },
                     "storage": {
                         "str:lentAmount": "150,000",
-                        "str:borrowMetadata|u64:1": "",
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "50,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/rewards-with-one-borrow.scen.json
+++ b/savings-account/mandos/rewards-with-one-borrow.scen.json
@@ -27,7 +27,6 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "5",
                     "str:completed"
                 ],
                 "gas": "*",
@@ -57,6 +56,24 @@
                                 "ESDTRoleNFTCreate",
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
+                            ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
                             ],
                             "lastNonce": "2"
                         },
@@ -105,14 +122,7 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [
-                    {
-                        "1-token-type": "u8:0",
-                        "2-token_id": "nested:str:STABLE-123456",
-                        "3-token_nonce": "u64:0",
-                        "4-amount": "biguint:2,500"
-                    }
-                ],
+                "out": [],
                 "gas": "*",
                 "refund": "*"
             }
@@ -140,6 +150,24 @@
                                 "ESDTRoleNFTCreate",
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
+                            ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
                             ],
                             "lastNonce": "2"
                         },
@@ -182,7 +210,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "1",
+                    "20",
                     "100,000"
                 ]
             },
@@ -199,7 +227,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "2",
+                    "21",
                     "50,000"
                 ]
             },
@@ -230,7 +258,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "3"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:50,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -282,6 +321,32 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:23"
+                                    }
+                                }
+                            ],
                             "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
@@ -295,18 +360,6 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
-                        "str:lendMetadata|u64:2": {
-                            "1-lend_epoch": "u64:21",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
-                        "str:lendMetadata|u64:3": {
-                            "1-lend_epoch": "u64:23",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
                         "str:lentAmount": "150,000",
                         "str:stablecoinReserves": "500",
                         "+": ""
@@ -323,7 +376,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "1",
+                    "20",
                     "50,000"
                 ]
             },
@@ -340,7 +393,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "3",
+                    "23",
                     "50,000"
                 ]
             },
@@ -371,7 +424,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "4"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:50,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:750"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -398,7 +462,18 @@
                 "status": "0",
                 "message": "",
                 "out": [
-                    "5"
+                    {
+                        "1-token_type": "u8:2",
+                        "2-token_id": "nested:str:LEND-123456",
+                        "3-token_nonce": "u64:3",
+                        "4-amount": "biguint:50,000"
+                    },
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:500"
+                    }
                 ],
                 "gas": "*",
                 "refund": "*"
@@ -416,13 +491,11 @@
                             "instances": [
                                 {
                                     "nonce": "3",
-                                    "balance": "50,000",
-                                    "creator": "sc:savings_account"
-                                },
-                                {
-                                    "nonce": "4",
-                                    "balance": "50,000",
-                                    "creator": "sc:savings_account"
+                                    "balance": "100,000",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:23"
+                                    }
                                 }
                             ]
                         }
@@ -437,9 +510,12 @@
                         "str:LEND-123456": {
                             "instances": [
                                 {
-                                    "nonce": "5",
+                                    "nonce": "3",
                                     "balance": "50,000",
-                                    "creator": "sc:savings_account"
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:23"
+                                    }
                                 }
                             ]
                         }
@@ -467,7 +543,33 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
-                            "lastNonce": "5"
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                },
+                                {
+                                    "nonce": "3",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:23"
+                                    }
+                                }
+                            ],
+                            "lastNonce": "3"
                         },
                         "str:BORROW-123456": {
                             "balance": "0",
@@ -480,20 +582,6 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": "",
-                        "str:lendMetadata|u64:2": "",
-                        "str:lendMetadata|u64:3": {
-                            "1-lend_epoch": "u64:23",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
-                        "str:lendMetadata|u64:4": {
-                            "1-lend_epoch": "u64:23",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
-                        "str:lendMetadata|u64:5": {
-                            "1-lend_epoch": "u64:23",
-                            "2-amount_in_circulation": "biguint:50,000"
-                        },
                         "str:lentAmount": "150,000",
                         "str:unclaimedRewards": "0",
                         "str:stablecoinReserves": "500",

--- a/savings-account/mandos/withdraw-with-rewards-full.scen.json
+++ b/savings-account/mandos/withdraw-with-rewards-full.scen.json
@@ -18,7 +18,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "2",
+                    "21",
                     "50,000"
                 ]
             },
@@ -50,7 +50,14 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [],
+                "out": [
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:53,167"
+                    }
+                ],
                 "gas": "*",
                 "refund": "*"
             }
@@ -62,7 +69,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "100,000",
+                        "str:STABLE-123456": "103,167",
                         "str:LEND-123456": {
                             "instances": []
                         }
@@ -73,7 +80,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "35,000",
+                        "str:STABLE-123456": "31,833",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -105,6 +112,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -118,36 +143,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
-                        "str:lendMetadata|u64:2": "",
                         "str:lentAmount": "100,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "75,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/mandos/withdraw-with-rewards-partial.scen.json
+++ b/savings-account/mandos/withdraw-with-rewards-partial.scen.json
@@ -18,7 +18,7 @@
                 "to": "sc:savings_account",
                 "function": "getLenderClaimableRewards",
                 "arguments": [
-                    "2",
+                    "21",
                     "50,000"
                 ]
             },
@@ -50,7 +50,14 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [],
+                "out": [
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:26,584"
+                    }
+                ],
                 "gas": "*",
                 "refund": "*"
             }
@@ -75,7 +82,14 @@
             "expect": {
                 "status": "0",
                 "message": "",
-                "out": [],
+                "out": [
+                    {
+                        "1-token_type": "u8:0",
+                        "2-token_id": "nested:str:STABLE-123456",
+                        "3-token_nonce": "u64:0",
+                        "4-amount": "biguint:26,175"
+                    }
+                ],
                 "gas": "*",
                 "refund": "*"
             }
@@ -87,7 +101,7 @@
                     "nonce": "*",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "101,584",
+                        "str:STABLE-123456": "102,759",
                         "str:LEND-123456": {
                             "instances": []
                         }
@@ -98,7 +112,7 @@
                     "nonce": "0",
                     "balance": "0",
                     "esdt": {
-                        "str:STABLE-123456": "33,416",
+                        "str:STABLE-123456": "32,241",
                         "str:LIQ-123456": {
                             "instances": [
                                 {
@@ -130,6 +144,24 @@
                                 "ESDTRoleNFTAddQuantity",
                                 "ESDTRoleNFTBurn"
                             ],
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:20"
+                                    }
+                                },
+                                {
+                                    "nonce": "2",
+                                    "balance": "1",
+                                    "creator": "sc:savings_account",
+                                    "attributes": {
+                                        "1-lend_epoch": "u64:21"
+                                    }
+                                }
+                            ],
                             "lastNonce": "2"
                         },
                         "str:BORROW-123456": {
@@ -143,36 +175,7 @@
                         }
                     },
                     "storage": {
-                        "str:lendMetadata|u64:1": {
-                            "1-lend_epoch": "u64:20",
-                            "2-amount_in_circulation": "biguint:100,000"
-                        },
-                        "str:lendMetadata|u64:2": "",
                         "str:lentAmount": "100,000",
-                        "str:borrowMetadata|u64:1": {
-                            "1-staking_position_id": "u64:1",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:2": {
-                            "1-staking_position_id": "u64:2",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:3": {
-                            "1-staking_position_id": "u64:3",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
-                        "str:borrowMetadata|u64:4": {
-                            "1-staking_position_id": "u64:4",
-                            "2-borrow_epoch": "u64:25",
-                            "3-staked_token_value_in_dollars_at_borrow": "biguint:100",
-                            "4-amount_in_circulation": "biguint:250,000,000,000,000,000,000"
-                        },
                         "str:borrowedAmount": "75,000",
                         "str:stakingPosition|u64:0": {
                             "1-prev_pos_id": "u64:0",

--- a/savings-account/meta/Cargo.toml
+++ b/savings-account/meta/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = ".."
 
 [dependencies.elrond-wasm]
-version = "0.30.0"
+version = "0.31.1"
 
 [dependencies.elrond-wasm-debug]
-version = "0.30.0"
+version = "0.31.1"

--- a/savings-account/src/lib.rs
+++ b/savings-account/src/lib.rs
@@ -296,7 +296,7 @@ pub trait SavingsAccount:
     #[endpoint]
     fn withdraw(
         &self,
-        #[var_args] opt_reject_if_penalty: OptionalValue<bool>,
+        opt_reject_if_penalty: OptionalValue<bool>,
     ) -> WithdrawResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
@@ -336,7 +336,7 @@ pub trait SavingsAccount:
     #[endpoint(lenderClaimRewards)]
     fn lender_claim_rewards(
         &self,
-        #[var_args] opt_reject_if_penalty: OptionalValue<bool>,
+        opt_reject_if_penalty: OptionalValue<bool>,
     ) -> ClaimRewardsResultType<Self::Api> {
         self.require_no_ongoing_operation();
 

--- a/savings-account/src/lib.rs
+++ b/savings-account/src/lib.rs
@@ -109,7 +109,7 @@ pub trait SavingsAccount:
 
     #[payable("*")]
     #[endpoint]
-    fn lend(&self) {
+    fn lend(&self) -> LendResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
         self.update_global_lender_rewards();
@@ -122,23 +122,21 @@ pub trait SavingsAccount:
         );
 
         let caller = self.blockchain().get_caller();
-        let new_lend_tokens = self
-            .lend_token()
-            .nft_create_and_send(&caller, payment_amount, &());
+        let current_epoch = self.blockchain().get_block_epoch();
+        let lend_nonce = self.get_or_create_lend_token_nonce(current_epoch);
+        let new_lend_tokens =
+            self.lend_token()
+                .nft_add_quantity_and_send(&caller, lend_nonce, payment_amount);
 
         self.lent_amount()
             .update(|lent_amount| *lent_amount += &new_lend_tokens.amount);
 
-        self.lend_metadata(new_lend_tokens.token_nonce)
-            .set(&LendMetadata {
-                lend_epoch: self.blockchain().get_block_epoch(),
-                amount_in_circulation: new_lend_tokens.amount,
-            });
+        new_lend_tokens
     }
 
     #[payable("*")]
     #[endpoint]
-    fn borrow(&self) {
+    fn borrow(&self) -> BorrowResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
         let payment: EsdtTokenPayment<Self::Api> = self.call_value().payment();
@@ -158,11 +156,19 @@ pub trait SavingsAccount:
 
         require!(borrow_value > 0, "Deposit amount too low");
 
-        let caller = self.blockchain().get_caller();
-        let borrow_tokens =
-            self.borrow_token()
-                .nft_create_and_send(&caller, payment.amount.clone(), &());
         let staking_pos_id = self.add_staking_position(payment.token_nonce);
+        let borrow_token_attributes = BorrowMetadata {
+            staking_position_id: staking_pos_id,
+            borrow_epoch: self.blockchain().get_block_epoch(),
+            staked_token_value_in_dollars_at_borrow: staked_token_value_in_dollars,
+        };
+
+        let caller = self.blockchain().get_caller();
+        let borrow_tokens = self.borrow_token().nft_create_and_send(
+            &caller,
+            payment.amount.clone(),
+            &borrow_token_attributes,
+        );
 
         let lent_amount = self.lent_amount().get();
         self.borrowed_amount().update(|total_borrowed| {
@@ -173,49 +179,33 @@ pub trait SavingsAccount:
             );
         });
 
-        self.borrow_metadata(borrow_tokens.token_nonce)
-            .set(&BorrowMetadata {
-                staking_position_id: staking_pos_id,
-                borrow_epoch: self.blockchain().get_block_epoch(),
-                staked_token_value_in_dollars_at_borrow: staked_token_value_in_dollars,
-                amount_in_circulation: payment.amount,
-            });
+        let stablecoins_payment = self.send_stablecoins(&caller, borrow_value);
 
-        self.send_stablecoins(&caller, &borrow_value);
+        (borrow_tokens, stablecoins_payment).into()
     }
 
     #[payable("*")]
     #[endpoint]
-    fn repay(&self) {
+    fn repay(&self) -> RepayResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
         let payments = self.call_value().all_esdt_transfers();
         require!(payments.len() == 2, REPAY_INVALID_PAYMENTS_ERR_MSG);
 
-        let first_payment = payments.get(0);
-        let second_payment = payments.get(1);
+        let first_payment: EsdtTokenPayment<Self::Api> = payments.get(0);
+        let second_payment: EsdtTokenPayment<Self::Api> = payments.get(1);
 
+        let borrow_token_mapper = self.borrow_token();
         let stablecoin_token_id = self.stablecoin_token_id().get();
-        let borrow_token_id = self.borrow_token().get_token_id();
         require!(
             first_payment.token_identifier == stablecoin_token_id,
-            "First transfer must be the Stablecoins"
+            REPAY_INVALID_PAYMENTS_ERR_MSG,
         );
-        require!(
-            second_payment.token_identifier == borrow_token_id,
-            "Second transfer must be the Borrow Tokens"
-        );
+        borrow_token_mapper.require_same_token(&second_payment.token_identifier);
 
         let stablecoin_amount = &first_payment.amount;
         let borrow_token_amount = &second_payment.amount;
         let borrow_token_nonce = second_payment.token_nonce;
-
-        let mut borrow_metadata = self.borrow_metadata(borrow_token_nonce).get();
-        self.update_borrow_metadata(
-            &mut borrow_metadata,
-            borrow_token_nonce,
-            borrow_token_amount,
-        );
 
         let borrowed_amount = self.borrowed_amount().get();
         let lent_amount = self.lent_amount().get();
@@ -234,6 +224,8 @@ pub trait SavingsAccount:
         let staking_position_current_value = self
             .compute_staking_position_value(&staked_token_value_in_dollars, borrow_token_amount);
 
+        let borrow_metadata: BorrowMetadata<Self::Api> =
+            borrow_token_mapper.get_token_attributes(borrow_token_nonce);
         let debt = self.compute_debt(
             &staking_position_current_value,
             borrow_metadata.borrow_epoch,
@@ -262,13 +254,12 @@ pub trait SavingsAccount:
                 .update(|stablecoin_reserves| *stablecoin_reserves += extra_reserves);
         }
 
-        self.borrow_token()
-            .nft_burn(borrow_token_nonce, borrow_token_amount);
+        borrow_token_mapper.nft_burn(borrow_token_nonce, borrow_token_amount);
 
         let caller = self.blockchain().get_caller();
         let extra_stablecoins_paid = stablecoin_amount - &total_stablecoins_needed;
         if extra_stablecoins_paid > 0u32 {
-            self.send_stablecoins(&caller, &extra_stablecoins_paid);
+            self.send_stablecoins(&caller, extra_stablecoins_paid);
         }
 
         let liquid_staking_token_id = self.liquid_staking_token_id().get();
@@ -293,11 +284,20 @@ pub trait SavingsAccount:
             borrow_token_amount,
             &[],
         );
+
+        EsdtTokenPayment::new(
+            liquid_staking_token_id,
+            liquid_staking_nonce,
+            borrow_token_amount.clone(),
+        )
     }
 
     #[payable("*")]
     #[endpoint]
-    fn withdraw(&self, #[var_args] opt_reject_if_penalty: OptionalValue<bool>) {
+    fn withdraw(
+        &self,
+        #[var_args] opt_reject_if_penalty: OptionalValue<bool>,
+    ) -> WithdrawResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
         self.update_global_lender_rewards();
@@ -306,7 +306,8 @@ pub trait SavingsAccount:
         let lend_token_mapper = self.lend_token();
         lend_token_mapper.require_same_token(&payment.token_identifier);
 
-        let mut lend_metadata = self.lend_metadata(payment.token_nonce).get();
+        let lend_metadata: LendMetadata =
+            lend_token_mapper.get_token_attributes(payment.token_nonce);
 
         let lent_amount = self.lent_amount().get();
         let borrowed_amount = self.borrowed_amount().get();
@@ -320,21 +321,23 @@ pub trait SavingsAccount:
 
         self.lent_amount()
             .update(|amount| *amount -= &payment.amount);
-        self.update_lend_metadata(&mut lend_metadata, payment.token_nonce, &payment.amount);
 
         let rewards_amount = self.try_claim_with_penalty(
-            payment.token_nonce,
+            lend_metadata.lend_epoch,
             &payment.amount,
             opt_reject_if_penalty,
         );
         let total_withdraw_amount = payment.amount + rewards_amount;
         let caller = self.blockchain().get_caller();
-        self.send_stablecoins(&caller, &total_withdraw_amount);
+        self.send_stablecoins(&caller, total_withdraw_amount)
     }
 
     #[payable("*")]
     #[endpoint(lenderClaimRewards)]
-    fn lender_claim_rewards(&self, #[var_args] opt_reject_if_penalty: OptionalValue<bool>) {
+    fn lender_claim_rewards(
+        &self,
+        #[var_args] opt_reject_if_penalty: OptionalValue<bool>,
+    ) -> ClaimRewardsResultType<Self::Api> {
         self.require_no_ongoing_operation();
 
         self.update_global_lender_rewards();
@@ -343,47 +346,41 @@ pub trait SavingsAccount:
         let lend_token_mapper = self.lend_token();
         lend_token_mapper.require_same_token(&payment.token_identifier);
 
-        let mut lend_metadata = self.lend_metadata(payment.token_nonce).get();
-        let last_valid_claim_epoch = self.last_rewards_update_epoch().get();
-        require!(
-            lend_metadata.lend_epoch < last_valid_claim_epoch,
-            NO_REWARDS_ERR_MSG
-        );
+        let lend_metadata: LendMetadata =
+            lend_token_mapper.get_token_attributes(payment.token_nonce);
+        let current_epoch = self.blockchain().get_block_epoch();
+        require!(lend_metadata.lend_epoch < current_epoch, NO_REWARDS_ERR_MSG);
 
         // burn old sfts
         lend_token_mapper.nft_burn(payment.token_nonce, &payment.amount);
 
         // create and send new sfts, with updated metadata
         let caller = self.blockchain().get_caller();
-        let new_lend_tokens =
-            lend_token_mapper.nft_create_and_send(&caller, payment.amount.clone(), &());
-
-        self.lend_metadata(new_lend_tokens.token_nonce)
-            .set(&LendMetadata {
-                lend_epoch: last_valid_claim_epoch,
-                amount_in_circulation: payment.amount.clone(),
-            });
+        let lend_nonce = self.get_or_create_lend_token_nonce(current_epoch);
+        let new_lend_tokens = lend_token_mapper.nft_add_quantity_and_send(
+            &caller,
+            lend_nonce,
+            payment.amount.clone(),
+        );
 
         let rewards_amount = self.try_claim_with_penalty(
-            payment.token_nonce,
+            lend_metadata.lend_epoch,
             &payment.amount,
             opt_reject_if_penalty,
         );
         require!(rewards_amount > 0, NO_REWARDS_ERR_MSG);
 
-        self.update_lend_metadata(&mut lend_metadata, payment.token_nonce, &payment.amount);
-
-        self.send_stablecoins(&caller, &rewards_amount);
+        let stablecoins_payment = self.send_stablecoins(&caller, rewards_amount);
+        (new_lend_tokens, stablecoins_payment).into()
     }
 
     fn try_claim_with_penalty(
         &self,
-        lend_token_nonce: u64,
+        lend_epoch: u64,
         lend_token_amount: &BigUint,
         opt_reject_if_penalty: OptionalValue<bool>,
     ) -> BigUint {
-        let mut rewards_amount =
-            self.get_lender_claimable_rewards(lend_token_nonce, lend_token_amount);
+        let mut rewards_amount = self.get_lender_claimable_rewards(lend_epoch, lend_token_amount);
         let penalty_amount = self.get_penalty_amount(&lend_token_amount);
         if penalty_amount > 0u32 {
             let reject = match opt_reject_if_penalty {
@@ -433,12 +430,12 @@ pub trait SavingsAccount:
     #[view(getLenderClaimableRewards)]
     fn get_lender_claimable_rewards_view(
         &self,
-        lend_token_nonce: u64,
+        lend_epoch: u64,
         lend_token_amount: BigUint,
     ) -> BigUint {
         self.update_global_lender_rewards();
 
-        let rewards = self.get_lender_claimable_rewards(lend_token_nonce, &lend_token_amount);
+        let rewards = self.get_lender_claimable_rewards(lend_epoch, &lend_token_amount);
         let penalty = self.get_penalty_amount(&lend_token_amount);
 
         if rewards > penalty {
@@ -450,20 +447,15 @@ pub trait SavingsAccount:
 
     fn get_lender_claimable_rewards(
         &self,
-        lend_token_nonce: u64,
+        lend_epoch: u64,
         lend_token_amount: &BigUint,
     ) -> BigUint {
-        if self.lend_metadata(lend_token_nonce).is_empty() {
-            return BigUint::zero();
-        }
-
-        let lend_metadata = self.lend_metadata(lend_token_nonce).get();
         let last_valid_claim_epoch = self.last_rewards_update_epoch().get();
         let lender_rewards_percentage_per_epoch = self.lender_rewards_percentage_per_epoch().get();
 
         self.compute_reward_amount(
             lend_token_amount,
-            lend_metadata.lend_epoch,
+            lend_epoch,
             last_valid_claim_epoch,
             &lender_rewards_percentage_per_epoch,
         )
@@ -481,36 +473,6 @@ pub trait SavingsAccount:
 
         self.blockchain()
             .get_sc_balance(&liquid_staking_token_id, liquid_staking_token_nonce)
-    }
-
-    fn update_lend_metadata(
-        &self,
-        lend_metadata: &mut LendMetadata<Self::Api>,
-        lend_nonce: u64,
-        payment_amount: &BigUint,
-    ) {
-        lend_metadata.amount_in_circulation -= payment_amount;
-
-        if lend_metadata.amount_in_circulation == 0 {
-            self.lend_metadata(lend_nonce).clear();
-        } else {
-            self.lend_metadata(lend_nonce).set(lend_metadata);
-        }
-    }
-
-    fn update_borrow_metadata(
-        &self,
-        borrow_metadata: &mut BorrowMetadata<Self::Api>,
-        borrow_nonce: u64,
-        payment_amount: &BigUint,
-    ) {
-        borrow_metadata.amount_in_circulation -= payment_amount;
-
-        if borrow_metadata.amount_in_circulation == 0 {
-            self.borrow_metadata(borrow_nonce).clear();
-        } else {
-            self.borrow_metadata(borrow_nonce).set(borrow_metadata);
-        }
     }
 
     #[storage_mapper("poolParams")]

--- a/savings-account/src/model.rs
+++ b/savings-account/src/model.rs
@@ -1,6 +1,12 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
+pub type LendResultType<M> = EsdtTokenPayment<M>;
+pub type BorrowResultType<M> = MultiValue2<EsdtTokenPayment<M>, EsdtTokenPayment<M>>;
+pub type RepayResultType<M> = EsdtTokenPayment<M>;
+pub type WithdrawResultType<M> = EsdtTokenPayment<M>;
+pub type ClaimRewardsResultType<M> = MultiValue2<EsdtTokenPayment<M>, EsdtTokenPayment<M>>;
+
 #[derive(TypeAbi, TopEncode, TopDecode)]
 pub struct PoolParams<M: ManagedTypeApi> {
     pub base_borrow_rate: BigUint<M>,
@@ -10,9 +16,8 @@ pub struct PoolParams<M: ManagedTypeApi> {
 }
 
 #[derive(TypeAbi, TopEncode, TopDecode)]
-pub struct LendMetadata<M: ManagedTypeApi> {
+pub struct LendMetadata {
     pub lend_epoch: u64,
-    pub amount_in_circulation: BigUint<M>,
 }
 
 #[derive(TypeAbi, TopEncode, TopDecode)]
@@ -20,5 +25,4 @@ pub struct BorrowMetadata<M: ManagedTypeApi> {
     pub staking_position_id: u64,
     pub borrow_epoch: u64,
     pub staked_token_value_in_dollars_at_borrow: BigUint<M>,
-    pub amount_in_circulation: BigUint<M>,
 }

--- a/savings-account/src/staking_rewards.rs
+++ b/savings-account/src/staking_rewards.rs
@@ -38,7 +38,7 @@ mod delegation_proxy {
         fn claim_rewards(
             &self,
             #[payment_multi] payments: ManagedVec<EsdtTokenPayment<Self::Api>>,
-            #[var_args] opt_receive_funds_func: OptionalValue<ManagedBuffer>,
+            opt_receive_funds_func: OptionalValue<ManagedBuffer>,
         );
     }
 }
@@ -134,7 +134,9 @@ pub trait StakingRewardsModule:
             self.delegation_proxy(self.delegation_sc_address().get())
                 .claim_rewards(
                     transfers,
-                    OptionalValue::Some(RECEIVE_STAKING_REWARDS_FUNC_NAME.into()),
+                    OptionalValue::Some(ManagedBuffer::new_from_bytes(
+                        RECEIVE_STAKING_REWARDS_FUNC_NAME,
+                    )),
                 )
                 .async_call()
                 .with_callback(
@@ -242,7 +244,7 @@ pub trait StakingRewardsModule:
                 staking_token_id,
                 staking_token_balance,
                 stablecoin_token_id.clone(),
-                1u32.into(),
+                1u32,
             )
             .execute_on_dest_context();
 

--- a/savings-account/wasm/Cargo.toml
+++ b/savings-account/wasm/Cargo.toml
@@ -21,9 +21,9 @@ panic = "abort"
 path = ".."
 
 [dependencies.elrond-wasm-node]
-version = "0.30.0"
+version = "0.31.1"
 features = [ "vm-validate-token-identifier" ]
 
 [dependencies.elrond-wasm-output]
-version = "0.30.0"
+version = "0.31.1"
 features = ["wasm-output-mode"]


### PR DESCRIPTION
- moved token metadata from storage to token attributes
- made it so lend tokens with the same lend_epoch always have the same nonce - this makes it so people with multiple lend positions will automatically merge them by claiming rewards
- added output payments as endpoint return
- upgraded to elrond-wasm 0.31.1